### PR TITLE
made executable, added exportpythonpath

### DIFF
--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -69,6 +69,7 @@ sbatch << EOF
 #SBATCH --ntasks=$CORES
 
 source /reg/g/psdm/etc/psconda.sh -py3
+export PYTHONPATH="${PYTHONPATH}:/cds/sw/package/autosfx/btx"
 
 echo "$MAIN_PY $CONFIGFILE"
 $MAIN_PY -c $CONFIGFILE


### PR DESCRIPTION
Updated elog_submit.sh by 1) making it executable, and 2) adding an `export PYTHONPATH` statement. Note that the latter is a temporary fix that should be made obsolete by the tpprwr repo. With these changes, the `make_powder` task successfully ran from the eLog.