### PR TITLE
Optimize distance task

### DIFF
--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -55,7 +55,7 @@ class AgBehenate:
         print("Detector distance inferred from powder rings: %s mm" % (np.round(distance,2)))
         return distance
     
-    def opt_distance(self, powder, est_distance, pixel_size, wavelength, center=None, plot=False):
+    def opt_distance(self, powder, est_distance, pixel_size, wavelength, center=None, plot=None):
         """
         Optimize the sample-detector distance based on the powder image.
         
@@ -71,8 +71,8 @@ class AgBehenate:
             beam wavelength in Angstrom
         center : tuple
             detector center (xc,yc) in pixels
-        plot : bool
-            if True, plot the results
+        plot : str or None
+            output path for figure; if '', plot but don't save; if None, don't plot
         
         Returns
         -------
@@ -94,18 +94,18 @@ class AgBehenate:
         peaks_predicted = q2pix(rings, wavelength, est_distance, pixel_size)
         opt_distance = self.detector_distance(peaks_predicted[0], wavelength, pixel_size)
         
-        if plot:
+        if plot is not None:
             self.visualize_results(powder, center=center, 
                                    peaks_predicted=peaks_predicted, peaks_observed=peaks_observed,
                                    scores=scores, Dq=self.delta_qs,
-                                   radialprofile=iprofile, qprofile=qprofile)
+                                   radialprofile=iprofile, qprofile=qprofile, plot=plot)
         
         return opt_distance
     
     def visualize_results(self, image, mask=None, vmax=50,
                           center=None, peaks_predicted=None, peaks_observed=None,
                           scores=None, Dq=None,
-                          radialprofile=None, qprofile=None):
+                          radialprofile=None, qprofile=None, plot=''):
         """
         Visualize fit, plotting (1) the residuals for the delta q scan, (2) the
         observed and predicted peaks in the radial intensity profile, and (3) the
@@ -154,3 +154,6 @@ class AgBehenate:
             if peaks_observed is not None:
                 for peak in peaks_observed:
                     circle = plt.Circle((center[0],center[1]), peak, fill=False, color='red', linestyle=':')
+        
+        if plot != '':
+            fig.savefig(plot, dpi=300)

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -14,7 +14,7 @@ class GeomOpt:
                                           run=run, # run number, int
                                           det_type=det_type) # detector name, str
         
-    def opt_distance(self, powder, sample='AgBehenate', center=None, plot=False):
+    def opt_distance(self, powder, sample='AgBehenate', center=None, plot=None):
         """
         Estimate the sample-detector distance based on the properties of the powder
         diffraction image. Currently only implemented for silver behenate.
@@ -28,8 +28,8 @@ class GeomOpt:
             sample type, currently implemented for AgBehenate only
         center : tuple
             detector center (xc,yc) in pixels. if None, assume assembled image center.
-        plot : bool
-            if True, visualize results of distance estimation
+        plot : str or None
+            output path for figure; if '', plot but don't save; if None, don't plot
 
         Returns
         -------

--- a/examples/make_powder.yaml
+++ b/examples/make_powder.yaml
@@ -1,11 +1,10 @@
 #
-#root_dir: '/cds/data/psdm/cxi/cxip20719/scratch/fpoitevi/powders/'
+root_dir: '/cds/data/psdm/mfx/mfxp19619/scratch/apeck/powders/'
 
-
-exp: 'cxix53120'
-run: '10'
-det_type: 'jungfrau4M'
+exp: 'mfxp19619'
+run: 19
+det_type: 'epix10k2M'
 
 task: 'make_powder'
-n_images: 1000
+n_images: 300
 batch_size: 100

--- a/examples/opt_distance.yaml
+++ b/examples/opt_distance.yaml
@@ -1,0 +1,11 @@
+#
+root_dir: '/cds/data/psdm/mfx/mfxp19619/scratch/apeck/stats/'
+
+exp: 'mfxp19619'
+run: 19
+det_type: 'epix10k2M'
+
+task: 'opt_distance'
+powder: '/cds/data/psdm/mfx/mfxp19619/scratch/apeck/powders/powder_max_r19.npy'
+center: 834 832.5
+plot: 'optd_run19.png'

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -69,7 +69,7 @@ sbatch << EOF
 #SBATCH --ntasks=$CORES
 
 source /reg/g/psdm/etc/psconda.sh -py3
-export PYTHONPATH="${PYTHONPATH}:/cds/sw/package/autosfx/btx"
+export PYTHONPATH="${PYTHONPATH}:/cds/home/a/apeck/btx"
 
 echo "$MAIN_PY $CONFIGFILE"
 $MAIN_PY -c $CONFIGFILE

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -69,7 +69,7 @@ sbatch << EOF
 #SBATCH --ntasks=$CORES
 
 source /reg/g/psdm/etc/psconda.sh -py3
-export PYTHONPATH="${PYTHONPATH}:/cds/home/a/apeck/btx"
+export PYTHONPATH="${PYTHONPATH}:/cds/sw/package/autosfx/btx"
 
 echo "$MAIN_PY $CONFIGFILE"
 $MAIN_PY -c $CONFIGFILE

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -7,7 +7,7 @@ import traceback
 import yaml
 
 from btx.misc.shortcuts import AttrDict, conditional_mkdir
-from tasks import test, make_powder
+from tasks import *
 
 def main():
     parser = argparse.ArgumentParser()
@@ -26,6 +26,8 @@ def main():
         test(config)
     elif(config.task == 'make_powder'):
         make_powder(config)
+    elif(config.task == 'opt_distance'):
+        opt_distance(config)
 
     return 0, 'Task successfully executed'
 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 
 from btx.diagnostics.run import RunDiagnostics
+from btx.diagnostics.geom_opt import GeomOpt
 from btx.misc.shortcuts import conditional_mkdir
 
 logging.basicConfig(level=logging.DEBUG)
@@ -12,6 +13,7 @@ def test(config):
     print(config)
 
 def make_powder(config):
+    """ Generate the max, avg, and std powders for a given run. """
     rd = RunDiagnostics(exp=config.exp,
                         run=config.run,
                         det_type=config.det_type)
@@ -23,3 +25,15 @@ def make_powder(config):
     rd.save_powders(config.root_dir)
     logger.debug('Done!')
     
+def opt_distance(config):
+    """ Optimize the detector distance from an AgBehenate run. """
+    geom_opt = GeomOpt(exp=config.exp,
+                       run=config.run,
+                       det_type=config.det_type)
+    config.center = tuple([float(elem) for elem in config.center.split()])
+    logger.debug(f'Optimizing detector distance for run {config.run} of {config.exp}...')
+    dist = geom_opt.opt_distance(powder=config.powder,
+                                 center=config.center,
+                                 plot=os.path.join(config.root_dir, config.plot))
+    logger.info(f'Detector distance inferred from powder rings: {dist} mm')
+    logger.debug('Done!')


### PR DESCRIPTION
An `opt_distance` task was added to estimate the detector distance using the `GeomOpt` class. The .yaml files were updated to run on a silver behenate run from experiment mfxp19619, and the `GeomOpt` code was amended to permit saving the relevant plot to disk. Running the following sequentially:
```
$ . elog_submit.sh -c ../examples/make_powder.yaml
$ . elog_submit.sh -c ../examples/opt_distance.yaml
```
yields the following estimate in the slurm*.out file: `Detector distance inferred from powder rings: 85.61 mm`.

@fredericpoitevin, how do we get the estimated distance to show up in the Workflow?