### PR TITLE
Peakfinder

### DIFF
--- a/btx/misc/shortcuts.py
+++ b/btx/misc/shortcuts.py
@@ -1,12 +1,5 @@
 import os
 
-def conditional_mkdir(path):
-    if not os.path.exists(path): # path does not exist, create it
-        os.makedirs(path)
-        return True
-
-    return True
-
 class AttrDict(dict):
     """ Nested Attribute Dictionary
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -97,5 +97,4 @@ if __name__ == '__main__':
     indexer_obj = Indexer(exp=params.exp, run=params.run, det_type=params.det_type, taskdir=params.taskdir, geom=params.geom, 
                           cell=params.cell, int_rad=params.int_rad, methods=params.methods, tolerance=params.tolerance, 
                           no_revalidate=params.no_revalidate, multi=params.multi, profile=params.profile)
-    #if indexer_obj.rank == 0:
     indexer_obj.write_exe()

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -1,0 +1,86 @@
+import numpy as np
+import argparse
+import os
+
+class Indexer:
+    
+    """ Index cxi files using indexamajig: https://www.desy.de/~twhite/crystfel/manual-indexamajig.html """
+
+    def __init__(self, exp, run, det_type, taskdir, geom, cell, int_rad='4,5,6', methods='mosflm',
+                 tolerance='5,5,5,1.5', no_revalidate=True, multi=True, profile=True):
+        
+        # general paramters
+        self.exp = exp
+        self.run = run
+        self.det_type = det_type
+        
+        # indexing parameters
+        self.geom = geom # geometry file in CrystFEL format
+        self.cell = cell # file containing unit cell information
+        self.rad = int_rad # list of str, radii of integration
+        self.methods = methods # str, indexing packages to run
+        self.tolerance = tolerance # list of str, tolerances for unit cell comparison
+        self.no_revalidate = no_revalidate # bool, skip validation step to omit iffy peaks
+        self.multi = multi # bool, enable multi-lattice indexing
+        self.profile = profile # bool, display timing data
+        self._retrieve_paths(taskdir)
+        self.nproc = os.environ['NCORES']
+  
+    def _retrieve_paths(self, taskdir):
+        """
+        Retrieve the paths for the input .lst and output .stream file 
+        consistent with the btx analysis directory structure.
+        
+        Parameters
+        ----------
+        taskdir : str
+            path to output folder for indexing results
+        """
+        self.lst = os.path.join(taskdir ,f'r{self.run:04}/r{self.run:04}.lst')
+        self.stream = os.path.join(taskdir, f'r{self.run:04}.stream')
+        if "TMP_EXE" in os.environ:
+            self.tmp_exe = os.environ['TMP_EXE']
+        else:
+            self.tmp_exe = os.path.join(taskdir ,f'r{self.run:04}/index_r{self.run:04}.sh')
+        
+    def write_exe(self):
+        """
+        Write an indexing executable for submission to slurm.
+        """        
+        command=f"indexamajig -i {self.lst} -o {self.stream} -j {self.nproc} -g {self.geom} --peaks=cxi --int-rad={self.rad} --indexing={self.methods} --pdb={self.cell} --tolerance={self.tolerance}"
+        if self.no_revalidate: command += ' --no-revalidate'
+        if self.multi: command += ' --multi'
+        if self.profile: command += ' --profile'
+
+        with open(self.tmp_exe, 'w') as f:
+            f.write("#!/bin/bash\n")
+            f.write(f"{command}\n")
+        print(f"Indexing executable written to {self.tmp_exe}")
+
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--exp', help='Experiment name', required=True, type=str)
+    parser.add_argument('-r', '--run', help='Run number', required=True, type=int)
+    parser.add_argument('-d', '--det_type', help='Detector name, e.g epix10k2M or jungfrau4M', required=True, type=str)
+    parser.add_argument('--taskdir', help='Base directory for indexing results', required=True, type=str)
+    parser.add_argument('--geom', help='CrystFEL-style geom file', required=True, type=str)
+    parser.add_argument('--cell', help='File containing unit cell information (.pdb or .cell)', required=True, type=str)
+    parser.add_argument('--int_rad', help='Integration radii for peak, buffer and background regions', required=False, type=str, default='4,5,6')
+    parser.add_argument('--methods', help='Indexing methods', required=False, type=str, default='xgandalf,mosflm,xds')
+    parser.add_argument('--tolerance', help='Tolerances for unit cell comparison: a,b,c,ang', required=False, type=str, default='5,5,5,1.5')
+    parser.add_argument('--no_revalidate', help='Skip validation step that omits peaks that are saturated, too close to detector edge, etc.', action='store_false')
+    parser.add_argument('--multi', help='Enable multi-lattice indexing', action='store_false')
+    parser.add_argument('--profile', help='Display timing data', action='store_false')
+    
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    
+    params = parse_input()
+    indexer_obj = Indexer(exp=params.exp, run=params.run, det_type=params.det_type, taskdir=params.taskdir, geom=params.geom, 
+                          cell=params.cell, int_rad=params.int_rad, methods=params.methods, tolerance=params.tolerance, 
+                          no_revalidate=params.no_revalidate, multi=params.multi, profile=params.profile)
+    indexer_obj.write_exe()

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -4,7 +4,6 @@ import h5py
 import os
 from mpi4py import MPI
 from btx.interfaces.psana_interface import *
-from btx.misc.shortcuts import conditional_mkdir
 from psalgos.pypsalgos import PyAlgos
 
 class PeakFinder:
@@ -126,7 +125,7 @@ class PeakFinder:
         tag : str
             file nomenclature suffix, optional
         """
-        conditional_mkdir(self.outdir)
+        os.makedirs(self.outdir, exist_ok=True)
         if (tag != '') and (tag[0]!='_'):
             tag = '_' + tag
         self.tag = tag # track for writing summary file

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -1,0 +1,482 @@
+import numpy as np
+import argparse
+import h5py
+import os
+from mpi4py import MPI
+from btx.interfaces.psana_interface import *
+from psalgos.pypsalgos import PyAlgos
+
+class PeakFinder:
+    
+    """
+    Perform adaptive peak-finding on a psana run and save the results to cxi
+    format. Adapted from psocake.
+    """
+    
+    def __init__(self, exp, run, det_type, outdir, tag='', mask=None, psana_mask=True, dist=None,
+                 min_peaks=2, max_peaks=2048, npix_min=2, npix_max=30, amax_thr=80., 
+                 atot_thr=120.,  son_min=7.0, peak_rank=3, r0=3.0, dr=2.0, nsigm=7.0):
+        
+        self.comm = MPI.COMM_WORLD
+        self.rank = self.comm.Get_rank()
+        self.size = self.comm.Get_size()
+        self.n_hits_per_rank = []
+        self.n_hits_total = 0
+        
+        # peak-finding algorithm parameters
+        self.npix_min = npix_min # int, min number of pixels in peak
+        self.npix_max = npix_max # int, max number of pixels in peak
+        self.amax_thr = amax_thr 
+        self.atot_thr = atot_thr
+        self.son_min = son_min # in psocake, nsigm=son_min
+        self.peak_rank = peak_rank # radius in which central pix is a local max, int
+        self.r0 = r0 # radius in pixels of ring for background evaluation, float
+        self.dr = dr # width in pixels of ring for background evaluation, float
+        self.nsigm = nsigm # intensity threshold to include pixel in connected group, float
+        self.min_peaks = min_peaks # int, min number of peaks per image
+        self.max_peaks = max_peaks # int, max number of peaks per image
+        self.dist = dist # float, distance to detector in mm, or str for a pv code
+        self.outdir = outdir # str, path for saving cxi files
+
+        # set up class
+        self.set_up_psana_interface(exp, run, det_type)
+        self.set_up_cxi(tag)
+        self.set_up_algorithm(mask_file=mask, psana_mask=psana_mask)
+        
+    def set_up_psana_interface(self, exp, run, det_type):
+        """
+        Set up PsanaInterface object and distribute events between ranks.
+        
+        Parameters
+        ----------
+        exp : str
+            experiment name
+        run : int
+            run number
+        det_type : str
+            detector name, e.g. jungfrau4M or epix10k2M
+        """
+        self.psi = PsanaInterface(exp=exp, run=run, det_type=det_type)
+        self.psi.distribute_events(self.rank, self.size)
+        self.n_events = self.psi.max_events
+
+        # additional self variables for tracking peak stats
+        self.iX = self.psi.det.indexes_x(self.psi.run).astype(np.int64)
+        self.iY = self.psi.det.indexes_y(self.psi.run).astype(np.int64)
+        self.ipx, self.ipy = self.psi.det.point_indexes(self.psi.run, pxy_um=(0, 0))
+
+        # retrieve psana-estimated distance if None or a PV code is supplied
+        if type(self.dist) != float:
+            if self.psi.det_type == 'jungfrau4M':
+                pv = 'CXI:DS1:MMS:06.RBV'
+            if self.psi.det_type == 'Rayonix':
+                pv = 'MFX:DET:MMS:04.RBV'
+            if self.psi.det_type == 'epix10k2M':
+                pv = 'MFX:ROB:CONT:POS:Z'
+            if type(self.dist) == str: # override default detector / PV
+                pv = self.dist
+            self.dist = self.psi.ds.env().epicsStore().value(pv)
+
+    def _generate_mask(self, mask_file=None, psana_mask=True):
+        """
+        Generate mask, optionally a combination of the psana-generated mask
+        and a user-supplied mask.
+        
+        Parameters
+        ----------
+        mask_file : str
+            path to mask in shape of unassembled detector, optional
+        psana_mask : bool
+            if True, retrieve mask from psana Detector object
+        """
+        mask = np.ones(self.psi.det.shape()).astype(np.uint16)  
+        if psana_mask:
+            mask = self.psi.det.mask(self.psi.run, calib=False, status=True, 
+                                     edges=False, centra=False, unbond=False, 
+                                     unbondnbrs=False).astype(np.uint16)
+        if mask_file is not None:
+            mask *= np.load(mask_file).astype(np.uint16)
+        
+        self.mask = mask
+        
+    def set_up_algorithm(self, mask_file=None, psana_mask=True):
+        """
+        Set up the peak-finding algorithm. Currently only the adaptive
+        variant is supported. For more details, see:
+        https://github.com/lcls-psana/psalgos/blob/master/src/pypsalgos.py 
+        """
+        self._generate_mask(mask_file=mask_file, psana_mask=psana_mask)
+        self.alg = PyAlgos(mask=self.mask, pbits=0) # pbits controls verbosity
+        self.alg.set_peak_selection_pars(npix_min=self.npix_min,
+                                         npix_max=self.npix_max,
+                                         amax_thr=self.amax_thr,
+                                         atot_thr=self.atot_thr,
+                                         son_min=self.son_min)
+        self.n_hits = 0
+        self.powder_hits, self.powder_misses = None, None
+
+    def set_up_cxi(self, tag=''):
+        """
+        Set up the CXI files to which peak finding results will be saved.
+        
+        Parameters
+        ----------
+        tag : str
+            file nomenclature suffix, optional
+        """
+        if (tag != '') and (tag[0]!='_'):
+            tag = '_' + tag
+        self.tag = tag # track for writing summary file
+        self.fname = os.path.join(self.outdir, f'{self.psi.exp}_{self.psi.run:04}_{self.rank}{tag}.cxi')
+        
+        outh5 = h5py.File(self.fname, 'w')
+        
+        # entry_1 dataset for downstream processing with CrystFEL
+        entry_1 = outh5.create_group("entry_1")
+        keys = ['nPeaks', 'peakXPosRaw', 'peakYPosRaw', 'rcent', 'ccent', 'rmin',
+                'rmax', 'cmin', 'cmax', 'peakTotalIntensity', 'peakMaxIntensity', 'peakRadius']
+        ds_expId = entry_1.create_dataset("experimental_identifier", (self.n_events,), maxshape=(None,), dtype=int)
+        ds_expId.attrs["axes"] = "experiment_identifier"
+        
+        # for storing images in crystFEL format
+        det_shape = self.psi.det.shape()
+        dim0, dim1 = det_shape[0] * det_shape[1], det_shape[2]
+        data_1 = entry_1.create_dataset('/entry_1/data_1/data', (self.n_events, dim0, dim1), chunks=(1, dim0, dim1),
+                                        maxshape=(None, dim0, dim1),dtype=np.float32)
+        data_1.attrs["axes"] = "experiment_identifier"
+        
+        for key in ['powderHits', 'powderMisses', 'mask']:
+            entry_1.create_dataset(f'/entry_1/data_1/{key}', (dim0, dim1), chunks=(dim0, dim1), maxshape=(dim0, dim1), dtype=float)
+                
+        # peak-related keys
+        for key in keys:
+            if key == 'nPeaks':
+                ds_x = outh5.create_dataset(f'/entry_1/result_1/{key}', (self.n_events,), maxshape=(None,), dtype=int)
+                ds_x.attrs['minPeaks'] = self.min_peaks
+                ds_x.attrs['maxPeaks'] = self.max_peaks
+            else:
+                ds_x = outh5.create_dataset(f'/entry_1/result_1/{key}', (self.n_events,self.max_peaks), 
+                                            maxshape=(None,self.max_peaks), chunks=(1,self.max_peaks), dtype=float)
+            ds_x.attrs["axes"] = "experiment_identifier:peaks"
+            
+        # LCLS dataset to track event timestamps
+        lcls_1 = outh5.create_group("LCLS")
+        keys = ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial', 'photon_energy_eV']
+        for key in keys:
+            if key == 'photon_energy_eV':
+                ds_x = lcls_1.create_dataset(f'{key}', (self.n_events,), maxshape=(None,), dtype=float)
+            else:
+                ds_x = lcls_1.create_dataset(f'{key}', (self.n_events,), maxshape=(None,), dtype=int)
+            ds_x.attrs["axes"] = "experiment_identifier"
+
+        ds_x = outh5.create_dataset('/LCLS/detector_1/EncoderValue', (self.n_events,), maxshape=(None,), dtype=float)
+        ds_x.attrs["axes"] = "experiment_identifier"
+            
+        outh5.close()
+    
+    def store_event(self, outh5, img, peaks, phot_energy):
+        """
+        Store event's peaks in CXI file, converting to Cheetah conventions.
+        
+        Parameters
+        ----------
+        outh5 : h5py._hl.files.File
+            open h5 file for storing output for this rank
+        img : numpy.ndarray, shape (n_panels, n_panels_fs, n_panels_ss)
+            calibrated detector data in shape of unassembled detector
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for a single event
+        phot_energy : float
+            photon energy in eV
+        """
+        if self.psi.det_type not in ['jungfrau4M', 'epix10k2M']:
+            print("Warning! Reformatting to Cheetah may not be correct")
+        
+        ch_rows = peaks[:,0] * img.shape[1] + peaks[:,1]
+        ch_cols = peaks[:,2]
+        
+        # entry_1 entries for crystFEL processing
+        outh5['/entry_1/data_1/data'][self.n_hits,:,:] = img.reshape(-1, img.shape[-1]) 
+        outh5['/entry_1/result_1/nPeaks'][self.n_hits] = peaks.shape[0] 
+        outh5['/entry_1/result_1/peakXPosRaw'][self.n_hits,:peaks.shape[0]] = ch_cols.astype('int')
+        outh5['/entry_1/result_1/peakYPosRaw'][self.n_hits,:peaks.shape[0]] = ch_rows.astype('int')
+        
+        outh5['/entry_1/result_1/rcent'][self.n_hits,:peaks.shape[0]] = peaks[:,6] # row center of gravity
+        outh5['/entry_1/result_1/ccent'][self.n_hits,:peaks.shape[0]] = peaks[:,7] # col center of gravity
+        outh5['/entry_1/result_1/rmin'][self.n_hits,:peaks.shape[0]] = peaks[:,10] # minimal row of pixel group in the peak
+        outh5['/entry_1/result_1/rmax'][self.n_hits,:peaks.shape[0]] = peaks[:,11] # maximal row of pixel group in the peak
+        outh5['/entry_1/result_1/cmin'][self.n_hits,:peaks.shape[0]] = peaks[:,12] # minimal col pixel group in the peak
+        outh5['/entry_1/result_1/cmax'][self.n_hits,:peaks.shape[0]] = peaks[:,13] # maximal col of pixel group in the peak
+        
+        outh5['/entry_1/result_1/peakTotalIntensity'][self.n_hits,:peaks.shape[0]] = peaks[:,5]
+        outh5['/entry_1/result_1/peakMaxIntensity'][self.n_hits,:peaks.shape[0]] = peaks[:,4]
+        outh5['/entry_1/result_1/peakRadius'][self.n_hits,:peaks.shape[0]] = self._compute_peak_radius(peaks)
+        
+        # LCLS dataset - currently omitting timetool information
+        outh5['/LCLS/eventNumber'][self.n_hits] = self.psi.counter
+        outh5['/LCLS/machineTime'][self.n_hits] = self.psi.seconds[-1]
+        outh5['/LCLS/machineTimeNanoSeconds'][self.n_hits] = self.psi.nanoseconds[-1]
+        outh5['/LCLS/fiducial'][self.n_hits] = self.psi.fiducials[-1]
+        outh5['/LCLS/photon_energy_eV'][self.n_hits] = phot_energy
+
+    def curate_cxi(self):
+        """
+        Curate the CXI file by reshaping the keys to the number of hits
+        and adding powders.
+        """
+        outh5 = h5py.File(self.fname,"r+")
+        
+        # resize the CrystFEL keys
+        data_shape = outh5["/entry_1/data_1/data"].shape
+        outh5['/entry_1/data_1/data'].resize((self.n_hits, data_shape[1], data_shape[2]))
+        outh5[f'/entry_1/result_1/nPeaks'].resize((self.n_hits,))
+
+        for key in ['peakXPosRaw', 'peakYPosRaw', 'rcent', 'ccent', 'rmin', 'rmax', 
+                    'cmin', 'cmax', 'peakTotalIntensity', 'peakMaxIntensity', 'peakRadius']:
+            outh5[f'/entry_1/result_1/{key}'].resize((self.n_hits, self.max_peaks))
+            
+        # add distance, then crop the LCLS keys
+        outh5['/LCLS/detector_1/EncoderValue'][:] = self.dist
+        for key in ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial', 'detector_1/EncoderValue', 'photon_energy_eV']:
+            outh5[f'/LCLS/{key}'].resize((self.n_hits,))
+
+        # add powders and mask, reshaping to match crystfel conventions
+        if self.powder_hits is not None:
+            outh5["/entry_1/data_1/powderHits"][:] = self.powder_hits.reshape(-1, self.powder_hits.shape[-1])
+        if self.powder_misses is not None:
+            outh5["/entry_1/data_1/powderMisses"][:] = self.powder_misses.reshape(-1, self.powder_misses.shape[-1])
+        outh5["/entry_1/data_1/mask"][:] = (1-self.mask).reshape(-1, self.mask.shape[-1]) # crystfel expects inverted values
+
+        outh5.close()
+    
+    def _compute_peak_radius(self, peaks):
+        """
+        Compute radii of peaks based on their constituent pixels.
+        
+        Parameters
+        ----------
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for a single event
+            
+        Returns 
+        -------
+        radius : numpy.ndarray, shape (n_peaks)
+            radii of peaks in pixels
+        """
+        cenX = self.iX[np.array(peaks[:, 0], dtype=np.int64),
+                       np.array(peaks[:, 1], dtype=np.int64),
+                       np.array(peaks[:, 2], dtype=np.int64)] + 0.5 - self.ipx
+        cenY = self.iY[np.array(peaks[:, 0], dtype=np.int64),
+                       np.array(peaks[:, 1], dtype=np.int64),
+                       np.array(peaks[:, 2], dtype=np.int64)] + 0.5 - self.ipy
+        return np.sqrt((cenX ** 2) + (cenY ** 2))
+        
+    def find_peaks_event(self, img):
+        """
+        Find peaks on a single image.
+        
+        Parameters
+        ----------
+        img : numpy.ndarray, shape (n_panels, n_panels_fs, n_panels_ss)
+            calibrated detector data in shape of unassembled detector
+            
+        Returns
+        -------
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for this image
+        """
+        peaks = self.alg.peak_finder_v3r3(img, rank=self.peak_rank, 
+                                          r0=self.r0, dr=self.dr, nsigm=self.nsigm) 
+        return peaks
+    
+    def find_peaks(self):
+        """
+        Find all peaks in the images assigned to this rank.
+        """
+        
+        start_idx, end_idx = self.psi.counter, self.psi.max_events
+        outh5 = h5py.File(self.fname,"r+")
+        empty_images = 0
+
+        for idx in range(start_idx, end_idx):
+            # retrieve calibrated image
+            evt = self.psi.runner.event(self.psi.times[self.psi.counter])
+            self.psi.get_timestamp(evt.get(EventId))
+            img = self.psi.det.calib(evt=evt)
+            if img is None:
+                empty_images += 1
+                continue
+
+            # search for peaks and store if found
+            peaks = self.find_peaks_event(img)
+            if (peaks.shape[0] >= self.min_peaks) and (peaks.shape[0] <= self.max_peaks):
+                try:
+                    phot_energy = 1.23984197386209e-06 / (self.psi.get_wavelength_evt(evt) / 10 / 1.0e9)
+                except AttributeError:
+                    print(f"AttributeError, evt type: {type(evt)} for event {evt}")
+                    phot_energy = 1.23984197386209e-06 / (self.psi.get_wavelength() / 10 / 1.0e9)
+                self.store_event(outh5, img, peaks, phot_energy)
+                self.n_hits+=1
+                
+            # generate / update powders
+            if peaks.shape[0] >= self.min_peaks:
+                if self.powder_hits is None:
+                    self.powder_hits = img
+                else:
+                    self.powder_hits = np.maximum(self.powder_hits, img)
+            else:
+                if self.powder_misses is None:
+                    self.powder_misses = img
+                else:
+                    self.powder_misses = np.maximum(self.powder_misses, img)
+                
+            self.psi.counter+=1
+            
+        outh5.close()
+        self.comm.Barrier()
+
+        if empty_images != 0:
+            print(f"Rank {self.rank} encountered {empty_images} empty images.")
+
+    def summarize(self):
+        """
+        Summarize results and write to peakfinding.summary file.
+        """
+        # grab summary stats
+        self.n_hits_per_rank = self.comm.gather(self.n_hits, root=0)
+        self.n_hits_total = self.comm.reduce(self.n_hits, MPI.SUM)
+        n_events_total = self.comm.reduce(self.n_events, MPI.SUM)
+        
+        if self.rank == 0:
+            # write summary file
+            with open(os.path.join(self.outdir, f'peakfinding{self.tag}.summary'), 'w') as f:
+                f.write(f"Number of events processed: {n_events_total}\n")
+                f.write(f"Number of hits found: {self.n_hits_total}\n")
+                f.write(f"Hit rate (%): {self.n_hits_total/n_events_total:.2f}\n")
+                f.write(f'No. hits per rank: {self.n_hits_per_rank}')
+
+            # generate virtual dataset and list for
+            vfname = os.path.join(self.outdir, f'{self.psi.exp}_{self.psi.run:04}{self.tag}.cxi')
+            self.generate_vds(vfname)
+            with open(os.path.join(self.outdir, f'r{self.psi.run:04}{self.tag}.lst'), 'w') as f:
+                f.write(f"{vfname}\n")
+        
+    def add_virtual_dataset(self, vfname, fnames, dname, shape, dtype, mode='a'):
+        """
+        Add a virtual dataset to the hdf5 file.
+
+        Parameters
+        ----------
+        vfname : str
+            filename for virtual CXI file
+        fnames : list of str
+            list of individual CXI file names
+        dname : str
+            dataset path within hdf5 file
+        shape : tuple
+            shape of virtual dataset
+        dtype : type
+            dataset type, e.g. int or float
+        mode : str
+            'w' if first dataset, 'a' otherwise
+        """
+        layout = h5py.VirtualLayout(shape=(self.n_hits_total,) + shape[1:], dtype=dtype)
+        cursor = 0
+        for i,fn in enumerate(fnames):
+            vsrc = h5py.VirtualSource(fn, dname, shape=(self.n_hits_per_rank[i],) + shape[1:])
+            if len(shape) == 1:
+                layout[cursor : cursor + self.n_hits_per_rank[i]] = vsrc
+            else:
+                layout[cursor : cursor + self.n_hits_per_rank[i], :] = vsrc
+            cursor += self.n_hits_per_rank[i]
+        with h5py.File(vfname, mode, libver="latest") as f:
+            f.create_virtual_dataset(dname, layout, fillvalue=-1)
+
+    def generate_vds(self, vfname):
+        """
+        Generate a virtual dataset to map all individual files for this run.
+
+        Parameters
+        ----------
+        vfname : str
+            filename for virtual CXI file    
+        """
+        if not hasattr(h5py, 'VirtualLayout'):
+            raise Exception("HDF5>=1.10 and h5py>=2.9 are required to generate a virtual dataset")
+            
+        # retrieve list of file names
+        fnames = []
+        for fi in range(self.size):
+            if self.n_hits_per_rank[fi] > 0:
+                fnames.append(os.path.join(self.outdir, f'{self.psi.exp}_{self.psi.run:04}_{fi}{self.tag}.cxi'))
+        if len(fnames) == 0:
+            sys.exit("No hits found")
+        print(f"Files with peaks: {fnames}")
+
+        # retrieve datasets to populate in virtual hdf5
+        dname_list, key_list, shape_list, dtype_list = [], [], [], []
+        datasets = ['/entry_1/result_1', '/LCLS/detector_1', '/LCLS', '/entry_1/data_1']
+        f = h5py.File(self.fname, "r")
+        for dname in datasets:
+            dset = f[dname]
+            for key in dset.keys():
+                if f'{dname}/{key}' not in datasets:
+                    dname_list.append(dname)
+                    key_list.append(key)
+                    shape_list.append(dset[key].shape)
+                    dtype_list.append(dset[key].dtype)
+        f.close()    
+
+        # populate virtual dataset
+        for dnum in range(len(dname_list)):
+            mode = 'a'
+            if dnum == 0: 
+                mode = 'w'
+            dname = f'{dname_list[dnum]}/{key_list[dnum]}'
+            if key_list[dnum] not in ['mask', 'powderHits', 'powderMisses']:
+                self.add_virtual_dataset(vfname, fnames, dname, shape_list[dnum], dtype_list[dnum], mode=mode)
+            if key_list[dnum] == 'mask':
+                layout = h5py.VirtualLayout(shape=shape_list[dnum], dtype=dtype_list[dnum])
+                vsrc = h5py.VirtualSource(fnames[0], dname, shape=shape_list[dnum])
+                layout[:] = vsrc
+                with h5py.File(vfname, "a", libver="latest") as f:
+                     f.create_virtual_dataset(dname, layout, fillvalue=-1)
+
+#### For command line use ####
+            
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--exp', help='Experiment name', required=True, type=str)
+    parser.add_argument('-r', '--run', help='Run number', required=True, type=int)
+    parser.add_argument('-d', '--det_type', help='Detector name, e.g epix10k2M or jungfrau4M',  required=True, type=str)
+    parser.add_argument('-o', '--outdir', help='Output directory for cxi files', required=True, type=str)
+    parser.add_argument('-t', '--tag', help='Tag to append to cxi file names', required=False, type=str, default='')
+    parser.add_argument('-m', '--mask', help='Binary mask', required=False, type=str)
+    parser.add_argument('--psana_mask', help='If True, apply mask from psana Detector object', required=False, type=bool, default=True)
+    parser.add_argument('--min_peaks', help='Minimum number of peaks per image', required=False, type=int, default=2)
+    parser.add_argument('--max_peaks', help='Maximum number of peaks per image', required=False, type=int, default=2048)
+    parser.add_argument('--npix_min', help='Minimum number of pixels per peak', required=False, type=int, default=2)
+    parser.add_argument('--npix_max', help='Maximum number of pixels per peak', required=False, type=int, default=30)
+    parser.add_argument('--amax_thr', help='', required=False, type=float, default=80.)
+    parser.add_argument('--atot_thr', help='', required=False, type=float, default=120.)
+    parser.add_argument('--son_min', help='', required=False, type=float, default=7.0)
+    parser.add_argument('--peak_rank', help='Radius in which central peak pixel is a local maximum', required=False, type=int, default=3)
+    parser.add_argument('--r0', help='Radius of ring for background evaluation in pixels', required=False, type=float, default=3.0)
+    parser.add_argument('--dr', help='Width of ring for background evaluation in pixels', required=False, type=float, default=2.0)
+    parser.add_argument('--nsigm', help='Intensity threshold to include pixel in connected group', required=False, type=float, default=7.0)
+    
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    
+    params = parse_input()
+    pf = PeakFinder(exp=params.exp, run=params.run, det_type=params.det_type, outdir=params.outdir, tag=params.tag,
+                    mask=params.mask, psana_mask=params.psana_mask, min_peaks=params.min_peaks, max_peaks=params.max_peaks,
+                    npix_min=params.npix_min, npix_max=params.npix_max, amax_thr=params.amax_thr, atot_thr=params.atot_thr, 
+                    son_min=params.son_min, peak_rank=params.peak_rank, r0=params.r0, dr=params.dr, nsigm=params.nsigm)
+    pf.find_peaks()
+    pf.curate_cxi()
+    pf.summarize()

--- a/dags/index_run.py
+++ b/dags/index_run.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+import os
+from airflow import DAG
+from plugins.jid import JIDSlurmOperator
+
+# DAG SETUP
+description='BTX index run DAG'
+dag_name = os.path.splitext(os.path.basename(__file__))[0]
+
+dag = DAG(
+    dag_name,
+    start_date=datetime( 2022,4,1 ),
+    schedule_interval=None,
+    description=description,
+  )
+
+
+# Tasks SETUP
+task_id='find_peaks'
+find_peaks = JIDSlurmOperator( task_id=task_id, dag=dag)
+
+task_id='index'
+index = JIDSlurmOperator( task_id=task_id, dag=dag)
+
+# Draw the DAG
+find_peaks >> index

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -50,6 +50,11 @@ do
       shift
       shift
       ;;
+    -e|--experiment)
+      EXPERIMENT="$2"
+      shift
+      shift
+      ;;
     *)
       POSITIONAL+=("$1")
       shift
@@ -74,16 +79,17 @@ sbatch << EOF
 #SBATCH --ntasks=${CORES}
 
 source /reg/g/psdm/etc/psconda.sh -py3  #TODO: get rid of hard-code
+export PATH=/cds/sw/package/crystfel/crystfel-dev/bin:$PATH
 export PYTHONPATH="${PYTHONPATH}:$( dirname -- $SCRIPT_DIR})"
+export NCORES=${CORES}
+export TMP_EXE="/cds/data/psdm/${EXPERIMENT:0:3}/${EXPERIMENT}/scratch/btx/task.sh"
 
-if [ ${CORES} -gt 1 ]
-then 
-echo "mpirun $MAIN_PY -c $CONFIGFILE -t $TASK"
-mpirun $MAIN_PY -c $CONFIGFILE -t $TASK
-else
-echo "$MAIN_PY -c $CONFIGFILE -t $TASK"
-$MAIN_PY -c $CONFIGFILE -t $TASK
+if [ ${CORES} -gt 1 ]; then
+MAIN_PY="mpirun ${MAIN_PY}"
 fi
+echo "$MAIN_PY -c $CONFIGFILE -t $TASK" 
+$MAIN_PY -c $CONFIGFILE -t $TASK
+if [ -f ${TMP_EXE} ]; then chmod +x ${TMP_EXE}; . ${TMP_EXE}; rm -f ${TMP_EXE}; fi
 EOF
 
 echo "Job sent to queue"

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -76,8 +76,14 @@ sbatch << EOF
 source /reg/g/psdm/etc/psconda.sh -py3  #TODO: get rid of hard-code
 export PYTHONPATH="${PYTHONPATH}:$( dirname -- $SCRIPT_DIR})"
 
+if [ ${CORES} -gt 1 ]
+then 
+echo "mpirun $MAIN_PY -c $CONFIGFILE -t $TASK"
+mpirun $MAIN_PY -c $CONFIGFILE -t $TASK
+else
 echo "$MAIN_PY -c $CONFIGFILE -t $TASK"
 $MAIN_PY -c $CONFIGFILE -t $TASK
+fi
 EOF
 
 echo "Job sent to queue"

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -67,6 +67,9 @@ QUEUE=${QUEUE:='psanaq'}
 CORES=${CORES:=1}
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 MAIN_PY="${SCRIPT_DIR}/main.py"
+if [ ${CORES} -gt 1 ]; then
+MAIN_PY="mpirun ${MAIN_PY}"
+fi
 
 #Submit to SLURM
 sbatch << EOF
@@ -84,9 +87,6 @@ export PYTHONPATH="${PYTHONPATH}:$( dirname -- $SCRIPT_DIR})"
 export NCORES=${CORES}
 export TMP_EXE="/cds/data/psdm/${EXPERIMENT:0:3}/${EXPERIMENT}/scratch/btx/task.sh"
 
-if [ ${CORES} -gt 1 ]; then
-MAIN_PY="mpirun ${MAIN_PY}"
-fi
 echo "$MAIN_PY -c $CONFIGFILE -t $TASK" 
 $MAIN_PY -c $CONFIGFILE -t $TASK
 if [ -f ${TMP_EXE} ]; then chmod +x ${TMP_EXE}; . ${TMP_EXE}; rm -f ${TMP_EXE}; fi

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 import yaml
 
-from btx.misc.shortcuts import AttrDict, conditional_mkdir
+from btx.misc.shortcuts import AttrDict
 from scripts.tasks import *
 
 def main():
@@ -20,9 +20,12 @@ def main():
         #TODO: check required arguments in config dictionary here.
 
     # Create output directory.
-    if not conditional_mkdir(config.setup.root_dir):
-        print(f"Error: cannot create root path.")
-        return -1
+    try:
+        os.makedirs(config.setup.root_dir, exist_ok=True)
+    except:
+        print(f"Error: cannot create root path.") 
+        return -1 
+
     # Copy config file to output directory.
     shutil.copy2(config_filepath, config.setup.root_dir)
     # Call 'task' function if it exists.

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -2,10 +2,6 @@ import logging
 import os
 import requests
 
-from btx.diagnostics.run import RunDiagnostics
-from btx.diagnostics.geom_opt import GeomOpt
-from btx.processing.peak_finder import PeakFinder
-
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -17,6 +13,7 @@ def test(config):
     requests.post(update_url, json=[config])
 
 def make_powder(config):
+    from btx.diagnostics.run import RunDiagnostics
     setup = config.setup
     task = config.make_powder
     """ Generate the max, avg, and std powders for a given run. """
@@ -32,6 +29,7 @@ def make_powder(config):
     logger.debug('Done!')
     
 def opt_distance(config):
+    from btx.diagnostics.geom_opt import GeomOpt
     setup = config.setup
     task = config.opt_distance
     """ Optimize the detector distance from an AgBehenate run. """
@@ -47,6 +45,7 @@ def opt_distance(config):
     logger.debug('Done!')
 
 def find_peaks(config):
+    from btx.processing.peak_finder import PeakFinder
     setup = config.setup
     task = config.find_peaks
     """ Perform adaptive peak finding on run. """
@@ -62,3 +61,16 @@ def find_peaks(config):
     pf.summarize() 
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
+
+def index(config):
+    from btx.processing.indexer import Indexer
+    setup = config.setup
+    task = config.find_peaks
+    """ Index run using indexamajig. """
+    taskdir = os.path.join(setup.root_dir, 'index')
+    indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, taskdir=taskdir, geom=config.index.geom,
+                          cell=config.index.cell, int_rad=config.index.int_radius, methods=config.index.methods, tolerance=config.index.tolerance, 
+                          no_revalidate=config.index.no_revalidate, multi=config.index.multi, profile=config.index.profile)
+    logger.debug(f'Generating indexing executable for run {setup.run} of {setup.exp}...')
+    indexer_obj.write_exe()
+    logger.info(f'Executable written to {indexer_obj.tmp_exe}')

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -49,7 +49,7 @@ def opt_distance(config):
 
 def find_peaks(config):
     setup = config.setup
-    task = config.opt_distance
+    task = config.find_peaks
     """ Perform adaptive peak finding on run. """
     taskdir = os.path.join(setup.root_dir, 'index')
     conditional_mkdir(taskdir)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -59,6 +59,7 @@ def find_peaks(config):
     pf.find_peaks()
     pf.curate_cxi()
     pf.summarize() 
+    pf.report(update_url)
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -2,7 +2,6 @@ import logging
 import os
 import requests
 
-from btx.misc.shortcuts import conditional_mkdir
 from btx.diagnostics.run import RunDiagnostics
 from btx.diagnostics.geom_opt import GeomOpt
 from btx.processing.peak_finder import PeakFinder
@@ -52,7 +51,7 @@ def find_peaks(config):
     task = config.find_peaks
     """ Perform adaptive peak finding on run. """
     taskdir = os.path.join(setup.root_dir, 'index')
-    conditional_mkdir(taskdir)
+    os.makedirs(taskdir, exist_ok=True)
     pf = PeakFinder(exp=setup.exp, run=setup.run, det_type=setup.det_type, outdir=os.path.join(taskdir ,f"r{setup.run:04}"), 
                     tag=task.tag, mask=task.mask, psana_mask=task.psana_mask, min_peaks=task.min_peaks, max_peaks=task.max_peaks,
                     npix_min=task.npix_min, npix_max=task.npix_max, amax_thr=task.amax_thr, atot_thr=task.atot_thr, 
@@ -61,5 +60,5 @@ def find_peaks(config):
     pf.find_peaks()
     pf.curate_cxi()
     pf.summarize() 
-    logger.info(f'Saving CXI files and summary to {task_dir}/r{setup.run:04}')
+    logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')

--- a/tutorial/index_run.yaml
+++ b/tutorial/index_run.yaml
@@ -1,0 +1,21 @@
+setup:
+  root_dir: '/cds/data/psdm/cxi/cxip21119/scratch/btx/'
+  exp: 'cxip21119'
+  run: 46
+  det_type: 'jungfrau4M'
+
+find_peaks:
+  tag: ''
+  mask: '/cds/data/psdm/cxi/cxip21119/scratch/apeck/r0046/staticMask.npy'
+  psana_mask: True
+  min_peaks: 2
+  max_peaks: 2048
+  npix_min: 2
+  npix_max: 30
+  amax_thr: 80.
+  atot_thr: 120.
+  son_min: 7.0
+  peak_rank: 3
+  r0: 3.0
+  dr: 2.0
+  nsigm: 7.0

--- a/tutorial/index_run.yaml
+++ b/tutorial/index_run.yaml
@@ -19,3 +19,15 @@ find_peaks:
   r0: 3.0
   dr: 2.0
   nsigm: 7.0
+
+index:
+  tag: ''
+  geom: '/cds/data/psdm/cxi/cxip21119/scratch/btx/index/r0046/r0046.geom'
+  int_radius: '4,5,6'
+  methods: 'mosflm'
+  cell: '/cds/data/psdm/cxi/cxip21119/scratch/btx/index/r0046/lox-stricter.cell'
+  tolerance: '5,5,5,1.5'
+  no_revalidate: True
+  multi: True
+  profile: True
+


### PR DESCRIPTION
A `PeakFinder` class has been added that leverages psana's adaptive peak-finding algorithm and writes the results to CrystFEL-compatible CXI files that can then be indexed using `indexamajig`. In addition, the class writes a summary file (peakfinding.summary) and a .lst file as input for `indexamajig`. A `find_peaks` task has been created that will be called by the `index_run` dag; a yaml has been created for the latter.

To enable MPI parallelization during peak finding, the `PsanaInterface` class has been revised so that the event IDs are retrieved at the beginning and can be distributed across ranks using the `distribute_events` class function. Note that despite these changes `PsanaInterface` has no knowledge of MPI so that it can be used without mpirun; `mpi4py` should be imported by the upstream class. It may be useful to look into `MPIDataSource` as an alternative at a later date.

A second note on parallelization: I found that the `conditional_mkdir` function failed in MPI node because the timing of different nodes creating / checking whether the directory already existed didn't work out. The following is now used as an alternative: `os.makedirs(config.setup.root_dir, exist_ok=True)`.