### PR TITLE
Parallelize `StreamInterface`

### DIFF
--- a/dags/det_distance.py
+++ b/dags/det_distance.py
@@ -16,11 +16,11 @@ dag = DAG(
 
 
 # Tasks SETUP
-task_id='make_powder'
-make_powder = JIDSlurmOperator( task_id=task_id, dag=dag)
+task_id='run_analysis'
+run_analysis = JIDSlurmOperator( task_id=task_id, dag=dag)
 
 task_id='opt_distance'
 opt_distance = JIDSlurmOperator( task_id=task_id, dag=dag)
 
 # Draw the DAG
-make_powder >> opt_distance
+run_analysis >> opt_distance

--- a/dags/hello_lcls.py
+++ b/dags/hello_lcls.py
@@ -13,6 +13,6 @@ with DAG(dag_id=dag_id, start_date=datetime(2022, 3, 28),
 
     #PythonOperator(task_id="say_hello", python_callable=say_hello)
     JIDSlurmOperator(
-        task_id='make_powder',
+        task_id='run_analysis',
         slurm_script='/reg/g/psdm/tutorials/batchprocessing/arp_submit.sh'
     )

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -14,10 +14,10 @@ def test(config):
     requests.post(update_url, json=[ { "key": "root_dir", "value": f"{config.setup.root_dir}" },
                                      { "key": "experiment_name", "value": "mfxp19619"} ])
 
-def make_powder(config):
+def run_analysis(config):
     from btx.diagnostics.run import RunDiagnostics
     setup = config.setup
-    task = config.make_powder
+    task = config.run_analysis
     """ Generate the max, avg, and std powders for a given run. """
     taskdir = os.path.join(setup.root_dir, 'powder')
     os.makedirs(taskdir, exist_ok=True)
@@ -82,20 +82,20 @@ def find_peaks(config):
 def index(config):
     from btx.processing.indexer import Indexer
     setup = config.setup
-    task = config.find_peaks
+    task = config.index
     """ Index run using indexamajig. """
     taskdir = os.path.join(setup.root_dir, 'index')
-    indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, taskdir=taskdir, geom=config.index.geom,
-                          cell=config.index.cell, int_rad=config.index.int_radius, methods=config.index.methods, tolerance=config.index.tolerance, 
-                          no_revalidate=config.index.no_revalidate, multi=config.index.multi, profile=config.index.profile)
+    indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, taskdir=taskdir, geom=task.geom,
+                          cell=task.cell, int_rad=task.int_radius, methods=task.methods, tolerance=task.tolerance, 
+                          no_revalidate=task.no_revalidate, multi=task.multi, profile=task.profile)
     logger.debug(f'Generating indexing executable for run {setup.run} of {setup.exp}...')
     indexer_obj.write_exe()
     logger.info(f'Executable written to {indexer_obj.tmp_exe}')
 
-def analyze_sample(config):
+def stream_analysis(config):
     from btx.interfaces.stream_interface import StreamInterface
     setup = config.setup
-    task = config.find_peaks
+    task = config.stream_analysis
     """ Diagnostics including cell distribution and peakogram. """
     taskdir = os.path.join(setup.root_dir, 'index')
     stream_files = glob.glob(os.path.join(taskdir, f"r*{task.tag}.stream"))

--- a/tutorial/mfxlv4920.yaml
+++ b/tutorial/mfxlv4920.yaml
@@ -1,7 +1,7 @@
 setup:
   root_dir: '/cds/data/psdm/mfx/mfxlv4920/scratch/apeck/'
   exp: 'mfxlv4920'
-  run: 4
+  run: 9
   det_type: 'epix10k2M'
 
 make_powder:
@@ -39,3 +39,5 @@ index:
   multi: True
   profile: True
 
+analyze_sample:
+  tag: ''

--- a/tutorial/mfxlv4920.yaml
+++ b/tutorial/mfxlv4920.yaml
@@ -4,7 +4,7 @@ setup:
   run: 9
   det_type: 'epix10k2M'
 
-make_powder:
+run_analysis:
   max_events: -1
   mask: '/cds/data/psdm/mfx/mfxlv4920/scratch/apeck/mrxv_mask.npy'
 
@@ -39,5 +39,5 @@ index:
   multi: True
   profile: True
 
-analyze_sample:
+stream_analysis:
   tag: ''


### PR DESCRIPTION
The `StreamInterface` class has been parallelized so that the input stream files (prior to merging) for a given sample (indicated by tag) are distributed across the available nodes during file reading. The contents of all the stream files are merged into the self variable `stream_data`, and the contents can be visualized in a peakogram or cell_explorer style plot. The latter can be generated as follows, for instance:
```
mpirun -n 3 python stream_interface.py -i="/cds/data/psdm/mfx/mfxlv4920/scratch/apeck/index/*stream" -o . --cell_only  
```
Omitting the `--cell_only` flag will cause the peakogram to be generated as well.

A task has been added that can be run from the command line for example as follows: 
```$ . elog_submit.sh -c ../tutorial/mfxlv4920.yaml -t analyze_sample -n 3```
and the mfxlv4920.yaml has been updated accordingly.