### PR TITLE
`build_mask` task

### DIFF
--- a/btx/interfaces/mask_interface.py
+++ b/btx/interfaces/mask_interface.py
@@ -15,18 +15,39 @@ class MaskInterface:
         
         self.psi = PsanaInterface(exp=self.exp, run=self.run, det_type=self.det_type) 
         self.pixel_index_map = retrieve_pixel_index_map(self.psi.det.geometry(self.run))
+
+    def mask_border_pixels(self, n_edge):
+        """
+        Mask the edge of each panel with a border n_edge pixels deep.
         
-    def generate_from_psana_run(self, thresholds, n_images=1):
+        Parameters
+        ----------
+        n_edge : int
+            number of pixels along each panel edge to mask
+        """
+        panel_mask = np.zeros(self.mask.shape[-2:]).astype(int)
+        panel_mask[n_edge:-n_edge,n_edge:-n_edge] = 1
+    
+        if len(self.mask.shape) == 2:
+            self.mask *= panel_mask
+        else:
+            for panel in range(self.mask.shape[0]):
+                self.mask[panel] *= panel_mask
+
+    def generate_from_psana_run(self, thresholds, n_images=1, n_edge=0):
         """
         Generate a mask by extracting n_images random images from the indicated run,
         thresholding each, and then merging them. A value of 0 indicates a bad pixel.
-        
+        If n_edge is supplied, the border pixels of each panel will be masked as well.
+
         Parameters
         ----------
         thresholds : tuple, 2d
             (lower, upper) thresholds for pixel value
         n_images : int
             number of images to threshold
+        n_edge : int
+            depth of border in pixels to mask for each panel
         """
         # retrieve n_images random events
         imgs = np.zeros((n_images,) + self.psi.det.shape())
@@ -45,6 +66,9 @@ class MaskInterface:
             self.mask = mask
         else:
             self.mask *= mask
+
+        if n_edge!=0:
+            self.mask_border_pixels(n_edge)
 
     def retrieve_from_mrxv(self, mrxv_path='/cds/sw/package/autosfx/mrxv/masks', dataset='/entry_1/data_1/mask'):
         """

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -56,7 +56,7 @@ def build_mask(config):
         mi.load_mask(mask_file, mask_format='psana')
         logger.debug(f'New mask will be combined with {mask_file}')
     task.thresholds = tuple([float(elem) for elem in task.thresholds.split()])
-    mi.generate_from_psana_run(thresholds=task.thresholds,n_images=task.n_images)
+    mi.generate_from_psana_run(thresholds=task.thresholds, n_images=task.n_images, n_edge=task.n_edge)
     logger.info(f'Saving newly generated mask to {taskdir}')
     mi.save_mask(os.path.join(taskdir, f'r{mi.psi.run:04}.npy'))
     logger.debug('Done!')

--- a/tutorial/mfxlv4920.yaml
+++ b/tutorial/mfxlv4920.yaml
@@ -1,7 +1,7 @@
 setup:
   root_dir: '/cds/data/psdm/mfx/mfxlv4920/scratch/apeck/'
   exp: 'mfxlv4920'
-  run: 235
+  run: 234
   det_type: 'Rayonix'
 
 fetch_mask:
@@ -12,6 +12,7 @@ fetch_geom:
 build_mask:
   thresholds: -10 2000
   n_images: 10
+  n_edge: 2
   combine: True
 
 run_analysis:

--- a/tutorial/mfxlv4920.yaml
+++ b/tutorial/mfxlv4920.yaml
@@ -9,6 +9,11 @@ fetch_mask:
 
 fetch_geom:
 
+build_mask:
+  thresholds: -10 2000
+  n_images: 10
+  combine: True
+
 run_analysis:
   max_events: -1
 


### PR DESCRIPTION
A `build_mask` task has been added that generates a mask by pulling random images from the run, applying thresholds, and then combining them into a binary mask. If the task flag `combine=True`, then this mask is merged with the previously used mask found in the `{config.root_dir}/mask` folder. This task can be run for example as follows:
```
$ . elog_submit.sh -c ../tutorial/mfxlv4920.yaml -t build_mask -n 1
```
The above yaml file has been updated accordingly.