### PR TITLE
Run on ffb

### DIFF
--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -9,6 +9,8 @@ $(basename "$0"):
   OPTIONS:
     -h|--help
       Definition of options
+    -f|--facility
+      Facility where we are running at
     -q|--queue
       Queue to use on SLURM
     -n|--ncores
@@ -29,6 +31,11 @@ do
     -h|--help)
       usage
       exit
+      ;;
+    -f|--facility)
+      FACILITY="$2"
+      shift
+      shift
       ;;
     -q|--queue)
       QUEUE="$2"
@@ -58,6 +65,17 @@ do
 done
 set -- "${POSITIONAL[@]}"
 
+FACILITY=${FACILITY:='SLAC'}
+case $FACILITY in
+  'SLAC')
+    SIT_PSDM_DATA_DIR='/cds/data/psdm/'
+    ;;
+  'SRCF_FFB')
+    SIT_PSDM_DATA_DIR='/cds/data/drpsrcf/'
+  *)
+    echo "ERROR! $FACILITY is not recognized."
+esac
+
 QUEUE=${QUEUE:='psanaq'}
 CORES=${CORES:=1}
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -83,6 +101,7 @@ source /reg/g/psdm/etc/psconda.sh -py3  #TODO: get rid of hard-code
 conda env list | grep '*'
 which mpirun
 which python
+export SIT_PSDM_DATA=${SIT_PSDM_DATA_DIR}
 export PATH=/cds/sw/package/crystfel/crystfel-dev/bin:$PATH
 export PYTHONPATH="${PYTHONPATH}:$( dirname -- ${SCRIPT_DIR})"
 export NCORES=${CORES}

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -72,8 +72,10 @@ case $FACILITY in
     ;;
   'SRCF_FFB')
     SIT_PSDM_DATA_DIR='/cds/data/drpsrcf/'
+    ;;
   *)
     echo "ERROR! $FACILITY is not recognized."
+    ;;
 esac
 
 QUEUE=${QUEUE:='psanaq'}


### PR DESCRIPTION
Added an argument to `elog_submit.sh` to let it know where it is running.

Successfully tested the following:
```bash
[fpoitevi@drp-srcf-eb001 fpoitevi]$ /cds/sw/package/autosfx/btx/scripts/elog_submit.sh -c mfxlv4920_ffb.yaml -t fetch_mask -n 1 -q ffbh3q -f 'SRCF_FFB'
```

with 
```yaml
[fpoitevi@drp-srcf-eb001 fpoitevi]$ cat mfxlv4920_ffb.yaml 
setup:
  root_dir: '/cds/data/drpsrcf/mfx/mfxlv4920/scratch/fpoitevi/btx/'
  exp: 'mfxlv4920'
  run: 234
  det_type: 'Rayonix'

fetch_mask:
  dataset: '/entry_1/data_1/mask'

fetch_geom:

```

got
```bash
[fpoitevi@drp-srcf-eb001 fpoitevi]$ pwd
/cds/data/drpsrcf/mfx/mfxlv4920/scratch/fpoitevi
[fpoitevi@drp-srcf-eb001 fpoitevi]$ ll -trh btx/mask/
total 29M
-rw-rw----+ 1 fpoitevi ps-data 29M May  1 18:19 r0000.npy
```