### PR TITLE
Cell free indexing and slight revisions to `geom_opt` display

### DIFF
--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -1,6 +1,9 @@
 import numpy as np
-import matplotlib.pyplot as plt
 from btx.misc.radial import radial_profile, q2pix, pix2q
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+import matplotlib.colors as colors
+from matplotlib.colors import LogNorm
 
 class AgBehenate:
     
@@ -102,7 +105,7 @@ class AgBehenate:
         
         return opt_distance
     
-    def visualize_results(self, image, mask=None, vmax=50,
+    def visualize_results(self, image, mask=None, vmax=None,
                           center=None, peaks_predicted=None, peaks_observed=None,
                           scores=None, Dq=None,
                           radialprofile=None, qprofile=None, plot=''):
@@ -143,6 +146,8 @@ class AgBehenate:
         ax3 = plt.subplot2grid((nrow, ncol), (irow, 0), rowspan=nrow-irow, colspan=ncol)
         if mask is not None:
             image *= mask
+        if vmax is None:
+            vmax = 2*np.mean(image)
         ax3.imshow(image,interpolation='none',vmin=0,vmax=vmax)
         ax3.set_title('Average Silver Behenate')
         if center is not None:

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -1,9 +1,5 @@
 import numpy as np
 import sys
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-import matplotlib.colors as colors
-from matplotlib.colors import LogNorm
 from btx.diagnostics.run import RunDiagnostics
 from btx.interfaces.psana_interface import assemble_image_stack_batch
 from .ag_behenate import *

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -1,4 +1,5 @@
 import numpy as np
+import sys
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.colors as colors

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -6,7 +6,7 @@ class Indexer:
     
     """ Index cxi files using indexamajig: https://www.desy.de/~twhite/crystfel/manual-indexamajig.html """
 
-    def __init__(self, exp, run, det_type, tag, taskdir, geom, cell, int_rad='4,5,6', methods='mosflm',
+    def __init__(self, exp, run, det_type, tag, taskdir, geom, cell=None, int_rad='4,5,6', methods='mosflm',
                  tolerance='5,5,5,1.5', no_revalidate=True, multi=True, profile=True):
         
         # general paramters
@@ -63,7 +63,8 @@ class Indexer:
         Write an indexing executable for submission to slurm.
         """     
         if self.rank == 0:
-            command=f"indexamajig -i {self.lst} -o {self.stream} -j {self.nproc} -g {self.geom} --peaks=cxi --int-rad={self.rad} --indexing={self.methods} --pdb={self.cell} --tolerance={self.tolerance}"
+            command=f"indexamajig -i {self.lst} -o {self.stream} -j {self.nproc} -g {self.geom} --peaks=cxi --int-rad={self.rad} --indexing={self.methods} --tolerance={self.tolerance}"
+            if self.cell is not None: command += ' --pdb={self.cell}'
             if self.no_revalidate: command += ' --no-revalidate'
             if self.multi: command += ' --multi'
             if self.profile: command += ' --profile'
@@ -83,7 +84,7 @@ def parse_input():
     parser.add_argument('-d', '--det_type', help='Detector name, e.g epix10k2M or jungfrau4M', required=True, type=str)
     parser.add_argument('--taskdir', help='Base directory for indexing results', required=True, type=str)
     parser.add_argument('--geom', help='CrystFEL-style geom file', required=True, type=str)
-    parser.add_argument('--cell', help='File containing unit cell information (.pdb or .cell)', required=True, type=str)
+    parser.add_argument('--cell', help='File containing unit cell information (.pdb or .cell)', required=False, type=str)
     parser.add_argument('--int_rad', help='Integration radii for peak, buffer and background regions', required=False, type=str, default='4,5,6')
     parser.add_argument('--methods', help='Indexing methods', required=False, type=str, default='xgandalf,mosflm,xds')
     parser.add_argument('--tolerance', help='Tolerances for unit cell comparison: a,b,c,ang', required=False, type=str, default='5,5,5,1.5')

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -64,7 +64,7 @@ class Indexer:
         """     
         if self.rank == 0:
             command=f"indexamajig -i {self.lst} -o {self.stream} -j {self.nproc} -g {self.geom} --peaks=cxi --int-rad={self.rad} --indexing={self.methods} --tolerance={self.tolerance}"
-            if self.cell is not None: command += ' --pdb={self.cell}'
+            if self.cell is not None: command += f' --pdb={self.cell}'
             if self.no_revalidate: command += ' --no-revalidate'
             if self.multi: command += ' --multi'
             if self.profile: command += ' --profile'

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -143,7 +143,7 @@ def index(config):
     taskdir = os.path.join(setup.root_dir, 'index')
     geom_file = fetch_latest(fnames=os.path.join(setup.root_dir, 'geom', 'r*.geom'), run=setup.run)
     indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, tag=task.tag, 
-                          taskdir=taskdir, geom=geom_file, cell=task.cell, int_rad=task.int_radius, methods=task.methods, 
+                          taskdir=taskdir, geom=geom_file, cell=task.get('cell'), int_rad=task.int_radius, methods=task.methods, 
                           tolerance=task.tolerance, no_revalidate=task.no_revalidate, multi=task.multi, profile=task.profile)
     logger.debug(f'Generating indexing executable for run {setup.run} of {setup.exp}...')
     indexer_obj.write_exe()


### PR DESCRIPTION
Indexing has been revised to enable cell-free indexing, which will be performed if a `cell` entry is not provided under the `index` task in the yaml.

The second set of changes involve moving specific matplotlib imports from geom_opt.py to ag_behenate.py (which actually does the plotting) and altering the default `vmax` value in the latter so that it's based on the powder intensities rather than an absolute value.