### PR TITLE
Rayonix2

### DIFF
--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -58,7 +58,7 @@ class AgBehenate:
         print("Detector distance inferred from powder rings: %s mm" % (np.round(distance,2)))
         return distance
     
-    def opt_distance(self, powder, est_distance, pixel_size, wavelength, center=None, plot=None):
+    def opt_distance(self, powder, est_distance, pixel_size, wavelength, mask=None, center=None, plot=None):
         """
         Optimize the sample-detector distance based on the powder image.
         
@@ -72,6 +72,8 @@ class AgBehenate:
             detector pixel size in mm
         wavelength : float
             beam wavelength in Angstrom
+        mask : numpy.ndarray, 2d
+            binary mask in shape of powder image
         center : tuple
             detector center (xc,yc) in pixels
         plot : str or None
@@ -88,7 +90,7 @@ class AgBehenate:
             center = (int(powder.shape[1]/2), int(powder.shape[0]/2))
         
         # determine peaks in radial intensity profile and associated positions in q
-        iprofile = radial_profile(powder, center=center)
+        iprofile = radial_profile(powder, center=center, mask=mask)
         peaks_observed, properties = find_peaks(iprofile, prominence=1, distance=10)
         qprofile = pix2q(np.arange(iprofile.shape[0]), wavelength, est_distance, pixel_size)
         
@@ -98,7 +100,7 @@ class AgBehenate:
         opt_distance = self.detector_distance(peaks_predicted[0], wavelength, pixel_size)
         
         if plot is not None:
-            self.visualize_results(powder, center=center, 
+            self.visualize_results(powder, mask=mask, center=center, 
                                    peaks_predicted=peaks_predicted, peaks_observed=peaks_observed,
                                    scores=scores, Dq=self.delta_qs,
                                    radialprofile=iprofile, qprofile=qprofile, plot=plot)

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -21,7 +21,7 @@ class GeomOpt:
         powder : str or int
             if str, path to the powder diffraction in .npy format
             if int, number of images from which to compute powder 
-        sampe : str
+        sample : str
             sample type, currently implemented for AgBehenate only
         center : tuple
             detector center (xc,yc) in pixels. if None, assume assembled image center.

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -53,7 +53,6 @@ class GeomOpt:
             mask = np.load(mask)
             if self.diagnostics.psi.det_type != 'Rayonix':
                 mask = assemble_image_stack_batch(mask, self.diagnostics.pixel_index_map)
-            powder_img *= mask
 
         if sample == 'AgBehenate':
             ag_behenate = AgBehenate()
@@ -61,6 +60,7 @@ class GeomOpt:
                                                 self.diagnostics.psi.estimate_distance(),
                                                 self.diagnostics.psi.get_pixel_size(), 
                                                 self.diagnostics.psi.get_wavelength(),
+                                                mask=mask,
                                                 center=center,
                                                 plot=plot)
             return distance

--- a/btx/interfaces/mask_interface.py
+++ b/btx/interfaces/mask_interface.py
@@ -49,9 +49,9 @@ class MaskInterface:
         n_edge : int
             depth of border in pixels to mask for each panel
         """
-        # retrieve n_images random events
+        # retrieve random events, excluding first of run due to Rayonix oddity
         imgs = np.zeros((n_images,) + self.psi.det.shape())
-        indices = np.random.randint(0, high=self.psi.max_events, size=n_images)
+        indices = np.random.randint(1, high=self.psi.max_events, size=n_images)
         for i,idx in enumerate(indices):
             evt = self.psi.runner.event(self.psi.times[idx])
             imgs[i] = self.psi.det.calib(evt=evt)

--- a/btx/misc/radial.py
+++ b/btx/misc/radial.py
@@ -1,6 +1,28 @@
 import numpy as np
 from scipy.signal import sosfiltfilt, butter
 
+def get_radius_map(shape, center=None):
+    """
+    Compute each pixel's radius for an array with input shape and center.
+    
+    Parameters
+    ----------
+    shape : tuple, 2d
+        dimensions of array
+    center : 2d tuple or array                                                                                                                                                                                     
+        (cx,cy) detector center in pixels; if None, choose image center     
+        
+    Returns
+    -------
+    r : numpy.ndarray, with input shape
+        map of pixels' radii
+    """
+    y, x = np.indices(shape)
+    if center is None:
+        center = (int(shape[1]/2), int(shape[0]/2))
+    r = np.sqrt((x - center[0])**2 + (y - center[1])**2)
+    return r
+
 def radial_profile(data, center=None, mask=None, 
                    filter=False, filter_order=2, filter_threshold=0.25,
                    threshold=10):
@@ -29,10 +51,9 @@ def radial_profile(data, center=None, mask=None,
     radialprofile : numpy.ndarray, 1d
         radial intensity profile of input image
     """
-    y, x = np.indices((data.shape))
     if center is None:
         center = (int(data.shape[1]/2), int(data.shape[0]/2))
-    r = np.sqrt((x - center[0])**2 + (y - center[1])**2)
+    r = get_radius_map(data.shape, center=center)
     if mask is not None:
         r = np.where(mask==1, r, 0)
     r = r.astype(np.int32)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -75,7 +75,7 @@ def run_analysis(config):
                         run=setup.run,
                         det_type=setup.det_type)
     logger.debug(f'Computing Powder for run {setup.run} of {setup.exp}...')
-    rd.compute_run_stats(max_events=task.max_events, mask=mask_file)
+    rd.compute_run_stats(max_events=task.max_events, mask=mask_file, threshold=task.get('mean_threshold'))
     logger.info(f'Saving Powders and plots to {taskdir}')
     rd.save_powders(taskdir)
     rd.visualize_powder(output=os.path.join(taskdir, f"figs/powder_r{rd.psi.run:04}.png"))

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -96,9 +96,11 @@ def opt_distance(config):
                        run=setup.run,
                        det_type=setup.det_type)
     task.center = tuple([float(elem) for elem in task.center.split()])
+    mask_file = fetch_latest(fnames=os.path.join(setup.root_dir, 'mask', 'r*.npy'), run=setup.run)
     logger.debug(f'Optimizing detector distance for run {setup.run} of {setup.exp}...')
     dist = geom_opt.opt_distance(powder=os.path.join(setup.root_dir, f"powder/r{setup.run:04}_max.npy"),
                                  center=task.center,
+                                 mask=mask_file,
                                  plot=os.path.join(taskdir, f'figs/r{setup.run:04}.png'))
     logger.info(f'Detector distance inferred from powder rings: {dist} mm')
     geom_in = fetch_latest(fnames=os.path.join(setup.root_dir, 'geom', 'r*.geom'), run=setup.run)


### PR DESCRIPTION
The changes in this commit mostly try to take care of the weird first event of each run on the Rayonix spotted in mfxp22820. See Issue #78. Specifically:
- In the `run_analysis` task, outlier events can optionally be excluded from both the powder and stats calculations based on the image mean by providing a `mean_threshold` parameter in the yaml. The latest mask is also fetched applied while calculating the stats trajectories (but not the powder).
- In the `generate_from_psana_run` function of `MaskInterface`, the first event is excluded from the random draw of images to generate the mask.
- The latest mask is fetched and applied to the powder during the `opt_distance` task. 

With the first change listed above, we no longer see the periodic gradual increase / sudden drop in the max intensity over the run or the artifactually overexposed first image:
![stats_r0002](https://user-images.githubusercontent.com/6363287/166853169-b3b15ce6-61e0-4d7d-92e6-d244aec4917e.png) 