### PR TITLE
making GeomOpt class parallel-compatible

### DIFF
--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sys
 import requests
+from mpi4py import MPI
 from btx.diagnostics.run import RunDiagnostics
 from btx.interfaces.psana_interface import assemble_image_stack_batch
 from btx.misc.metrology import *
@@ -16,6 +17,10 @@ class GeomOpt:
         self.center = None
         self.distance = None
         self.edge_resolution = None
+
+        # have a rank variable available in case we're running via a multi-core DAG
+        comm = MPI.COMM_WORLD
+        self.rank = comm.Get_rank()
 
     def opt_geom(self, powder, sample='AgBehenate', mask=None, center=None, 
                  n_iterations=5, n_peaks=3, threshold=1e6, plot=None):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -94,24 +94,25 @@ def opt_geom(config):
     geom_opt = GeomOpt(exp=setup.exp,
                        run=setup.run,
                        det_type=setup.det_type)
-    mask_file = fetch_latest(fnames=os.path.join(setup.root_dir, 'mask', 'r*.npy'), run=setup.run)
-    logger.debug(f'Optimizing detector distance for run {setup.run} of {setup.exp}...')
-    geom_opt.opt_geom(powder=os.path.join(setup.root_dir, f"powder/r{setup.run:04}_max.npy"),
-                      mask=mask_file,
-                      n_iterations=task.get('n_iterations'), 
-                      n_peaks=task.get('n_peaks'), 
-                      threshold=task.get('threshold'),
-                      plot=os.path.join(taskdir, f'figs/r{setup.run:04}.png'))
-    try:
-        geom_opt.report(update_url)
-    except:
-        logger.debug("Could not communicate with the elog update url")
-    logger.info(f'Detector distance in mm inferred from powder rings: {geom_opt.distance}')
-    logger.info(f'Detector center in pixels inferred from powder rings: {geom_opt.center}')
-    logger.info(f'Detector edge resolution in Angstroms: {geom_opt.edge_resolution}')    
-    geom_opt.deploy_geometry(taskdir)
-    logger.info(f'Updated geometry files saved to: {taskdir}')
-    logger.debug('Done!')
+    if geom_opt.rank == 0:
+        mask_file = fetch_latest(fnames=os.path.join(setup.root_dir, 'mask', 'r*.npy'), run=setup.run)
+        logger.debug(f'Optimizing detector distance for run {setup.run} of {setup.exp}...')
+        geom_opt.opt_geom(powder=os.path.join(setup.root_dir, f"powder/r{setup.run:04}_max.npy"),
+                          mask=mask_file,
+                          n_iterations=task.get('n_iterations'), 
+                          n_peaks=task.get('n_peaks'), 
+                          threshold=task.get('threshold'),
+                          plot=os.path.join(taskdir, f'figs/r{setup.run:04}.png'))
+        try:
+            geom_opt.report(update_url)
+        except:
+            logger.debug("Could not communicate with the elog update url")
+        logger.info(f'Detector distance in mm inferred from powder rings: {geom_opt.distance}')
+        logger.info(f'Detector center in pixels inferred from powder rings: {geom_opt.center}')
+        logger.info(f'Detector edge resolution in Angstroms: {geom_opt.edge_resolution}')    
+        geom_opt.deploy_geometry(taskdir)
+        logger.info(f'Updated geometry files saved to: {taskdir}')
+        logger.debug('Done!')
 
 def find_peaks(config):
     from btx.processing.peak_finder import PeakFinder

--- a/tutorial/test.yaml
+++ b/tutorial/test.yaml
@@ -1,5 +1,0 @@
-setup:
-  root_dir: '/cds/data/psdm/mfx/mfxp19619/scratch/test/'
-
-test:
-  parameter: 'value'


### PR DESCRIPTION
As noted in Issue #102, sometimes the `opt_geom` DAG produces an empty geom file. I suspect that this is because multiple ranks may try writing to the same geom file when run from the DAG (and thus using multiple cores), so the `GeomOpt` class has been updated to have some knowledge of ranks in the hopes that this will resolve the issue. 