### PR TITLE
Minor changes to `AgBehenate` class and dependencies

### DIFF
--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -83,7 +83,7 @@ class AgBehenate:
         print("Detector distance inferred from powder rings: %s mm" % (np.round(distance,2)))
         return distance
     
-    def opt_distance(self, plot=None):
+    def opt_distance(self, plot=None, vmax=None):
         """
         Optimize the sample-detector distance based on the powder image.
         
@@ -91,6 +91,8 @@ class AgBehenate:
         ----------
         plot : str or None
             output path for figure; if '', plot but don't save; if None, don't plot
+        vmax : float 
+            vmax value for powder plot 
         
         Returns
         -------
@@ -112,7 +114,7 @@ class AgBehenate:
         opt_distance = self.detector_distance(peaks_predicted[0])
         
         if plot is not None:
-            self.visualize_results(self.powder, mask=self.mask, center=self.centers[-1], 
+            self.visualize_results(self.powder, mask=self.mask, vmax=vmax, center=self.centers[-1], 
                                    peaks_predicted=peaks_predicted, peaks_observed=peaks_observed,
                                    scores=scores, Dq=self.delta_qs,
                                    radialprofile=iprofile, qprofile=qprofile, plot=plot)
@@ -154,7 +156,7 @@ class AgBehenate:
                 
         print(f"New center is {(self.centers[-1][0], self.centers[-1][1])}")
         
-    def opt_geom(self, distance_i, n_iterations=5, n_peaks=3, threshold=1e6, center_i=None, plot=None):
+    def opt_geom(self, distance_i, n_iterations=5, n_peaks=3, threshold=1e6, center_i=None, plot=None, vmax=None):
         """
         Optimize the detector geometry, sequentially refining the distance and center
         in an iterative fashion.
@@ -173,6 +175,8 @@ class AgBehenate:
             initial estimate of detector center in pixels
         plot : str or None
             if a legitimate path, save plot; if empty str, display plot; if None, don't plot
+        vmax : float
+            vmax value for powder plot
         """
         # store initial distance and center
         self.distances.append(distance_i)
@@ -186,11 +190,11 @@ class AgBehenate:
             self.powder[self.powder>threshold] = 0
             
         # iterate over distance and center estimation
-        peaks_obs, peak_vals = self.opt_distance(plot=plot)
+        peaks_obs, peak_vals = self.opt_distance(plot=plot, vmax=vmax)
         for niter in range(n_iterations):
             peaks_obs_sel = peaks_obs[np.argsort(peak_vals[:8])[::-1][:n_peaks]] # highest intensity peaks from first 8 in q.
             self.opt_center(peaks_obs_sel)
-            peaks_obs, peak_vals = self.opt_distance(plot=plot)
+            peaks_obs, peak_vals = self.opt_distance(plot=plot, vmax=vmax)
     
     def visualize_results(self, image, mask=None, vmax=None,
                           center=None, peaks_predicted=None, peaks_observed=None,
@@ -234,7 +238,9 @@ class AgBehenate:
         if mask is not None:
             image *= mask
         if vmax is None:
-            vmax = 2*np.mean(image)
+            # heuristic for decent vmax based on examining several powders
+            peakvals = radialprofile[peaks_observed]
+            vmax = 1.5*np.mean(peakvals[np.argsort(peakvals[:8])[::-1][2:5]])
         ax3.imshow(image,interpolation='none',vmin=0,vmax=vmax)
         ax3.set_title('Average Silver Behenate')
         if center is not None:

--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -242,7 +242,7 @@ class AgBehenate:
             peakvals = radialprofile[peaks_observed]
             vmax = 1.5*np.mean(peakvals[np.argsort(peakvals[:8])[::-1][2:5]])
         ax3.imshow(image,interpolation='none',vmin=0,vmax=vmax)
-        ax3.set_title('Average Silver Behenate')
+        ax3.set_title('Max Silver Behenate')
         if center is not None:
             ax3.plot(center[0],center[1],'ro')
             if peaks_predicted is not None:

--- a/btx/diagnostics/ag_behenate.py
+++ b/btx/diagnostics/ag_behenate.py
@@ -120,7 +120,7 @@ class AgBehenate:
         self.distances.append(opt_distance)
         return peaks_observed, iprofile[peaks_observed]
     
-    def opt_center(self, peaks_observed, num=200):
+    def opt_center(self, peaks_observed, num_circle_points=200):
         """
         Optimize the detector center by fitting circles to pixels predicted
         to fall in the powder rings.
@@ -129,22 +129,22 @@ class AgBehenate:
         ----------
         peaks_observed : numpy.ndarray, 1d
             radii of detected powder peaks in pixels
-        num : int
-            number of points per ring to use for fitting
+        num_circle_points : int
+            number of points per powder ring to use for fitting
         """
         # Create a concentric circle model...
         cx, cy = self.centers[-1]
-        model = OptimizeConcentricCircles(cx=cx, cy=cy, r=peaks_observed, num=num)
+        model = OptimizeConcentricCircles(cx=cx, cy=cy, r=peaks_observed, num_circle_points=num_circle_points)
         model.generate_crds()
         crds_init = model.crds.copy()
-        crds_init = crds_init.reshape(2, -1, num)
+        crds_init = crds_init.reshape(2, -1, num_circle_points)
 
         # Fitting...
         img = (self.powder - np.mean(self.powder)) / np.std(self.powder)
         res = model.fit(img)
         model.report_fit(res)
         crds = model.crds
-        crds = crds.reshape(2, -1, num)
+        crds = crds.reshape(2, -1, num_circle_points)
 
         # Update the center position...
         cx = res.params['cx'].value

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -130,6 +130,16 @@ class GeomOpt:
         modify_crystfel_header(temp_file, crystfel_file)
         os.remove(temp_file)
 
+        # Rayonix check
+        if self.diagnostics.psi.get_pixel_size() != self.diagnostics.psi.det.pixel_size(run):
+            print("Original geometry is wrong due to hardcoded Rayonix pixel size. Correcting geom file now...")
+            coffset = (self.distance - self.diagnostics.psi.get_camera_length()) / 1e3 # convert from mm to m
+            res = 1e3 / self.diagnostics.psi.get_pixel_size() # convert from mm to um
+            os.rename(crystfel_file, temp_file)
+            modify_crystfel_coffset_res(temp_file, crystfel_file, coffset, res)
+            os.remove(psana_file)
+            os.remove(temp_file)
+
     def report(self, update_url):
         """
         Post summary to elog.

--- a/btx/misc/metrology.py
+++ b/btx/misc/metrology.py
@@ -31,6 +31,40 @@ def retrieve_from_mrxv(det_type, out_geom, mrxv_path='/cds/sw/package/autosfx/mr
 
     geom.to_crystfel_file(out_geom)
 
+def modify_crystfel_coffset_res(input_file, output_file, coffset, res):
+    """
+    Overwrite the coffset and res entries in a CrystFEL .geom file. This is a 
+    hack to fix Rayonix geom files generated using the wrong pixel size.
+    
+    Parameters
+    ----------
+    input_file : str
+        input .geom file
+    output_file : str
+        output modified .geom file
+    coffset : float
+        coffset value in meters
+    res : float
+        pixel resolution in um
+    """
+    outfile = open(output_file, "w")
+
+    with open(input_file, "r") as infile:
+        for line in infile.readlines():
+            
+            if 'coffset' in line:
+                start = line.split("=")[0].strip(" ")
+                outfile.write(f"{start} = {coffset}\n")
+                
+            elif "res = " in line:
+                start = line.split("=")[0].strip(" ")
+                outfile.write(f"{start} = {res}\n")
+            
+            else:
+                outfile.write(line)
+
+    outfile.close()
+
 def modify_crystfel_header(input_file, output_file):
     """
     Modify the header of a psgeom-generated Crystfel (.geom) file,

--- a/btx/misc/radial.py
+++ b/btx/misc/radial.py
@@ -116,14 +116,14 @@ def q2pix(qvals, wavelength, distance, pixel_size):
 
 class ConcentricCircles:
 
-    def __init__(self, cx, cy, r, num = 100):
+    def __init__(self, cx, cy, r, num_circle_points = 100):
         super().__init__()
 
-        self.cx  = cx                                # Beam center position in pixels along x-axis (axis = 1 in numpy format)
-        self.cy  = cy                                # Beam center position in pixels along y-axis
-        self.r   = np.array([r]).reshape(-1)         # List of radii for all concentric circles in pixels
-        self.num = num                               # Number of pixels sampled from a circle
-        self.crds = np.zeros((2, num * len(self.r))) # Coordinates where pixels are sampled from all circles.  Unit is pixel.  2 is the size of (x, y)
+        self.cx  = cx                                              # Beam center position in pixels along x-axis (axis = 1 in numpy format)
+        self.cy  = cy                                              # Beam center position in pixels along y-axis
+        self.r   = np.array([r]).reshape(-1)                       # List of radii for all concentric circles in pixels
+        self.num_circle_points = num_circle_points                 # Number of pixels sampled from a circle
+        self.crds = np.zeros((2, num_circle_points * len(self.r))) # Coordinates where pixels are sampled from all circles.  Unit is pixel.  2 is the size of (x, y)
 
     def generate_crds(self):
         """
@@ -135,7 +135,7 @@ class ConcentricCircles:
         r  = np.array([self.r]).reshape(-1, 1) # Facilitate broadcasting in calculting crds_x and crds_y
 
         # Find all theta values for generating coordinates of sample points...
-        theta = np.linspace(0.0, 2 * np.pi, self.num)
+        theta = np.linspace(0.0, 2 * np.pi, self.num_circle_points)
         if not isinstance(theta, np.ndarray): theta = np.array([theta]).reshape(-1)
 
         # Generate coordinates...
@@ -166,8 +166,8 @@ class ConcentricCircles:
 
 class OptimizeConcentricCircles(ConcentricCircles):
 
-    def __init__(self, cx, cy, r, num):
-        super().__init__(cx, cy, r, num)
+    def __init__(self, cx, cy, r, num_circle_points):
+        super().__init__(cx, cy, r, num_circle_points)
 
         # Provide parameters for optimization...
         self.params = self.init_params()
@@ -194,7 +194,7 @@ class OptimizeConcentricCircles(ConcentricCircles):
 
         Parameters
         ----------
-        params : dictionary
+        params : dict
             parameters for optimization
 
         Returns
@@ -206,15 +206,17 @@ class OptimizeConcentricCircles(ConcentricCircles):
 
     def residual_model(self, params, img, **kwargs):
         """
-        Calculate the residual for least square optimization.
+        Calculate the residual for least square optimization. The residual
+        is computed as the difference between the intensity values of pixels
+        that belong to the rings and the image's maximum intensity value.
 
         Parameters
         ----------
-        params : dictionary
+        params : dict
             parameters for optimization
         img : numpy.ndarray
             a powder image
-        kwargs : dictionary
+        kwargs : dict
             additional key-value arguments
         
         Returns


### PR DESCRIPTION
Minor changes include:
- updating a docstring and variable name in the Concentric Circle classes in radial.py, addressing Issue #96.
- changing the default `vmax` value for the powder plot. This seems to provide a decent display for a range of experiments, addressing Issue #103.
- Making the `vmax` adjustable while running the `AgBehenate` class, for example as follows:
```
psi = PsanaInterface(exp='mfxp22820', run=57, det_type='Rayonix')
ag_behenate = AgBehenate(powder, mask, psi.get_pixel_size(), psi.get_wavelength())
ag_behenate.opt_geom(psi.estimate_distance(),  plot='', vmax=vmax) 
```
This still isn't currently an adjustable variable from the elog, but will be made so when the `GeomOpt` class and associated task are restructured in the coming days (see Issue #127). 