### PR TITLE
optionally supply an estimated sample-detector distance in the `opt_geom` task

### DIFF
--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -22,7 +22,7 @@ class GeomOpt:
         comm = MPI.COMM_WORLD
         self.rank = comm.Get_rank()
 
-    def opt_geom(self, powder, sample='AgBehenate', mask=None, center=None, 
+    def opt_geom(self, powder, sample='AgBehenate', mask=None, center=None, distance=None,
                  n_iterations=5, n_peaks=3, threshold=1e6, plot=None):
         """
         Estimate the sample-detector distance based on the properties of the powder
@@ -39,6 +39,8 @@ class GeomOpt:
             npy file of mask in psana unassembled detector shape
         center : tuple
             detector center (xc,yc) in pixels. if None, assume assembled image center.
+        distance : float
+            sample-detector distance in mm. If None, pull from calib file.
         n_iterations : int
             number of refinement steps
         n_peaks : int
@@ -72,12 +74,15 @@ class GeomOpt:
             if self.diagnostics.psi.det_type != 'Rayonix':
                 mask = assemble_image_stack_batch(mask, self.diagnostics.pixel_index_map)
 
+        if distance is None:
+            distance = self.diagnostics.psi.estimate_distance()
+
         if sample == 'AgBehenate':
             ag_behenate = AgBehenate(powder_img,
                                      mask,
                                      self.diagnostics.psi.get_pixel_size(),
                                      self.diagnostics.psi.get_wavelength())
-            ag_behenate.opt_geom(self.diagnostics.psi.estimate_distance(), 
+            ag_behenate.opt_geom(distance, 
                                  n_iterations=n_iterations, 
                                  n_peaks=n_peaks, 
                                  threshold=threshold, 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -99,6 +99,7 @@ def opt_geom(config):
         logger.debug(f'Optimizing detector distance for run {setup.run} of {setup.exp}...')
         geom_opt.opt_geom(powder=os.path.join(setup.root_dir, f"powder/r{setup.run:04}_max.npy"),
                           mask=mask_file,
+                          distance=task.get('distance'),
                           n_iterations=task.get('n_iterations'), 
                           n_peaks=task.get('n_peaks'), 
                           threshold=task.get('threshold'),


### PR DESCRIPTION
In `GeomOpt`, we base the initial distance estimate on the value in the relevant -end.data file. If this is larger and too far away from the true distance, the correct distance may not be found. To address this issue, one can optionally supply an initial distance estimate in the `opt_geom` task.