### PR TITLE
Updates to `StreamInterface`: report cell parameters and write to CrystFEL cell file

### DIFF
--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -186,8 +186,9 @@ def merge(config):
     taskdir = os.path.join(setup.root_dir, 'merge')
     os.makedirs(taskdir, exist_ok=True)
     input_stream = os.path.join(setup.root_dir, f"index/{task.tag}.stream")
+    cellfile = os.path.join(setup.root_dir, f"cell/{task.tag}.cell")
     foms = task.foms.split(" ")
-    stream_to_mtz = StreamtoMtz(input_stream, task.symmetry, taskdir, task.cell)
+    stream_to_mtz = StreamtoMtz(input_stream, task.symmetry, taskdir, cellfile)
     stream_to_mtz.cmd_partialator(iterations=task.iterations, model=task.model, min_res=task.get('min_res'), push_res=task.get('push_res'))
     for ns in [1, task.nshells]:
         stream_to_mtz.cmd_compare_hkl(foms=foms, nshells=ns, highres=task.get('highres'))

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -166,16 +166,17 @@ def stream_analysis(config):
     st = StreamInterface(input_files=glob.glob(stream_files), cell_only=False)
     if st.rank == 0:
         logger.debug(f'Read stream files: {stream_files}')
+        st.report()
         st.plot_cell_parameters(output=os.path.join(taskdir, f"figs/cell_{task.tag}.png"))
         st.plot_peakogram(output=os.path.join(taskdir, f"figs/peakogram_{task.tag}.png"))
         logger.info(f'Peakogram and cell distribution generated for sample {task.tag}')
         celldir = os.path.join(setup.root_dir, 'cell')
         os.makedirs(celldir, exist_ok=True)
         write_cell_file(st.cell_params, os.path.join(celldir, f"{task.tag}.cell"), input_file=setup.get('cell'))
-        logger.info(f'Input stream files: {stream_files}')
-        logger.info(f'Concatenating all stream files to {task.tag}.stream')
+        logger.info(f'Wrote updated CrystFEL cell file to {celldir}')
         stream_cat = os.path.join(taskdir, f"{task.tag}.stream")
         os.system(f"cat {stream_files} >> {stream_cat}")
+        logger.info(f'Concatenated all stream files to {task.tag}.stream')
         logger.debug('Done!')
 
 def merge(config):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -156,7 +156,7 @@ def index(config):
     logger.info(f'Executable written to {indexer_obj.tmp_exe}')
 
 def stream_analysis(config):
-    from btx.interfaces.stream_interface import StreamInterface
+    from btx.interfaces.stream_interface import StreamInterface, write_cell_file
     setup = config.setup
     task = config.stream_analysis
     """ Diagnostics including cell distribution and peakogram. Concatenate streams. """
@@ -169,6 +169,9 @@ def stream_analysis(config):
         st.plot_cell_parameters(output=os.path.join(taskdir, f"figs/cell_{task.tag}.png"))
         st.plot_peakogram(output=os.path.join(taskdir, f"figs/peakogram_{task.tag}.png"))
         logger.info(f'Peakogram and cell distribution generated for sample {task.tag}')
+        celldir = os.path.join(setup.root_dir, 'cell')
+        os.makedirs(celldir, exist_ok=True)
+        write_cell_file(st.cell_params, os.path.join(celldir, f"{task.tag}.cell"), input_file=setup.get('cell'))
         logger.info(f'Input stream files: {stream_files}')
         logger.info(f'Concatenating all stream files to {task.tag}.stream')
         stream_cat = os.path.join(taskdir, f"{task.tag}.stream")

--- a/tutorial/ap_mfxp22820.yaml
+++ b/tutorial/ap_mfxp22820.yaml
@@ -3,6 +3,7 @@ setup:
   exp: 'mfxp22820'
   run: 57
   det_type: 'Rayonix'
+  cell: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck/cell/prime.cell'
 
 fetch_mask:
   dataset: '/entry_1/data_1/mask'
@@ -55,7 +56,6 @@ stream_analysis:
 merge:
   tag: 'sample3'
   symmetry: '2/m_uab'
-  cell: '/cds/data/psdm/mfx/mfxp22820/scratch/btx/sample.cell'
   iterations: 1
   model: 'unity'
   foms: 'CC Rsplit'


### PR DESCRIPTION
The `StreamInterface` class has been updated to:
1. write the observed unit cell parameters (mean and standard deviation) to a summary file and report to the elog if an `update_url` path is found.
2. write a new CrystFEL-style cell file, which is then used during the `merge` task.
3. fix the error in computing the mean cell parameters displayed in the cell explorer plot. (Previously I had neglected to take into account that the first column of `self.stream_data` -- corresponding to the crystal index -- reverts to 0 for each stream file in the input list rather than continuously incrementing.)