### PR TITLE
fixing bizarre max powder (memory?) issue

### DIFF
--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -37,7 +37,7 @@ class RunDiagnostics:
         """
         if not self.powders:
             for key in ['sum', 'sqr', 'max']:
-                self.powders[key] = img
+                self.powders[key] = img.copy()
         else:
             self.powders['sum'] += img
             self.powders['sqr'] += np.square(img)


### PR DESCRIPTION
@fredericpoitevin -- you were right! It seems to only be the first time that `img` is assigned that needs to be copied. Thanks for catching that!