### PR TITLE
Adding clustering / cell parameter determination for cell-free indexing

### DIFF
--- a/tutorial/ap_mfxp22820.yaml
+++ b/tutorial/ap_mfxp22820.yaml
@@ -53,6 +53,10 @@ index:
 stream_analysis:
   tag: 'sample2'
 
+determine_cell:
+  tag: 'sample2'
+  input_cell: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck/cell/prime.cell'
+
 merge:
   tag: 'sample2'
   symmetry: '2/m_uab'


### PR DESCRIPTION
The following changes have been made:
- A function to cluster cell parameters using DBSCAN. Two output files are written: 1. a summary file listing the cell parameters and frequencies of all valid clusters and 2. a CrystFEL-style .cell file based on the top cluster.
- A `determine_cell` task that can be run via elog_submit.sh. Example parameters for this task can be found in the updated ap_mfxp22820.yaml.