### PR TITLE
Geometry refinement tasks

### DIFF
--- a/btx/misc/shortcuts.py
+++ b/btx/misc/shortcuts.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import glob
+import time
 
 class AttrDict(dict):
     """ Nested Attribute Dictionary
@@ -55,3 +56,23 @@ def fetch_latest(fnames, run):
     sort_idx = np.argsort(avail)
     idx = np.searchsorted(avail[sort_idx], run, side='right') - 1
     return fnames[sort_idx[idx]]
+
+def check_file_existence(fname, timeout, frequency=15):
+    """
+    Pause until a given file exists, exiting if the waiting
+    period exceeds timeout.
+    
+    Parameters
+    ----------
+    fname : str
+        name of file whose existence to check for
+    timeout : float
+        permitted waiting period in seconds
+    frequency : float
+        frequency with which to check in seconds
+    """
+    start_time = time.time() 
+    while time.time() - start_time < timeout:
+        if os.path.exists(fname):
+            break
+        time.sleep(frequency)

--- a/tutorial/ap_mfxlx5520_ffb.yaml
+++ b/tutorial/ap_mfxlx5520_ffb.yaml
@@ -1,10 +1,10 @@
 setup:
-  queue: psanaq
-  root_dir: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck'
-  exp: 'mfxp22820'
-  run: 10
+  queue: ffbh4q
+  root_dir: '/cds/data/drpsrcf/mfx/mfxlx5520/scratch/btx_elog/'
+  exp: 'mfxlx5520'
+  run: 1
   det_type: 'Rayonix'
-  cell: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck/cell/prime.cell'
+  cell: '/cds/data/drpsrcf/mfx/mfxlx5520/scratch/btx_elog/cell/cco_ox-pre.cell'
 
 fetch_mask:
   dataset: '/entry_1/data_1/mask'
@@ -24,42 +24,38 @@ opt_geom:
   n_iterations: 5
   n_peaks: 3
   threshold: 1000000
-  distance: 200
 
 find_peaks:
-  tag: ''
+  tag: 'day3_cluster1_manualfix'
   psana_mask: False
   min_peaks: 10
   max_peaks: 2048
   npix_min: 2
   npix_max: 30
-  amax_thr: 40.
-  atot_thr: 180.
+  amax_thr: 20.
+  atot_thr: 30.
   son_min: 10.0
-  peak_rank: 3
-  r0: 3.0
+  peak_rank: 5
+  r0: 5.0
   dr: 2.0
   nsigm: 10.0
 
 index:
-  tag: 'sample2'
+  tag_cxi: 'day3_cluster1_manualfix'
+  tag: 'sample1_day1_cluster1'
   int_radius: '3,4,5'
   methods: 'mosflm'
-  cell: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck/cell/prime.cell'
+  cell: '/cds/data/drpsrcf/mfx/mfxlx5520/scratch/btx_elog/cell/cco_ox-pre.cell'
   tolerance: '5,5,5,1.5'
   no_revalidate: True
   multi: True
   profile: True
 
 stream_analysis:
-  tag: 'sample2'
-
-determine_cell:
-  tag: 'sample2'
-  input_cell: '/cds/data/psdm/mfx/mfxp22820/scratch/apeck/cell/prime.cell'
+  tag: 'sample1_day1_cluster1'
 
 merge:
-  tag: 'sample2'
+  tag: 'sample1_day1_cluster1'
   symmetry: '2/m_uab'
   iterations: 1
   model: 'unity'
@@ -68,10 +64,10 @@ merge:
   highres: 2.5
 
 refine_center:
-  runs: 48 56
+  runs: 100 105
   dx: -1 1 3
   dy: -1 1 3
  
 refine_distance:
-  runs: 48 56 1
+  runs: 100 105
   dz: -0.001 0.001 5


### PR DESCRIPTION
(You really don't want to see how this refinement sausage was made.)

Geometry refinement tasks (`refine_center`, `refine_distance`, `refine_geometry` have been added. These scan over center and/or distance offsets starting from the relevant CrystFEL geometry file in the geom folder and create a new geometry file based on the offsets that minimize Rsplit of the merged data.

As an example, these tasks were run as follows: 
```
$ . elog_submit.sh -c ../tutorial/ap_mfxlx5520_ffb.yaml -t refine_center -n 1 -q ffbh4q -f 'SRCF_FFB' 
$ . elog_submit.sh -c ../tutorial/ap_mfxlx5520_ffb.yaml -t refine_distance -n 1 -q ffbh4q -f 'SRCF_FFB' 
```
The relevant yaml file has been pushed as well.