### PR TITLE
Add peak finder visualizers

### DIFF
--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -94,7 +94,7 @@ class PeakFinder:
             if True, retrieve mask from psana Detector object
         """
         mask = np.ones(self.psi.det.shape()).astype(np.uint16)  
-        if psana_mask:
+        if psana_mask and self.psi.det_type!='Rayonix':
             mask = self.psi.det.mask(self.psi.run, calib=False, status=True, 
                                      edges=False, centra=False, unbond=False, 
                                      unbondnbrs=False).astype(np.uint16)


### PR DESCRIPTION
(Unfortunately this PR was only started but not finished on the day of le Grand Départ, this year from Copenhagen!)

A function to visualize the results of peak finding was adapted from the UXSS tutorial and added to peak_finder.py. It plots both the powder hits and misses and a random selection of individual "hits" with the observed peaks marked. This function has been tested on representative experiments that used a Rayonix (mfxp22820) and a jungfrau4M (xpptut15). 

Because it's hard to automate selecting a good `vmax`, I'm not sure that this should be added to the `find_peaks` task (since presumably a user will want to adjust this parameter without re-running peak finding). A separate visualization task might work, but it seems cumbersome to keep on editing the yaml until a good value is found. For now it's a standalone function not included in any task; perhaps this is a subject to revisit when considering interactive plotting?

An example call is:
```
visualize_hits('./uxss2022/xpptut15_r0580.cxi', exp='xpptut15', run=580, det_type='jungfrau4M', vmax_ind=5, vmax_powder=15)
```
which yields the following:
![download](https://user-images.githubusercontent.com/6363287/178080044-9df92605-3cb2-4415-b1be-cc83297906d9.png)
![download-1](https://user-images.githubusercontent.com/6363287/178080047-81c9600e-3550-45db-8bd5-6be38f1d4f8f.png)

Another minor change was made to prevent the `PeakFinder` class from trying to retrieve a psana mask in Rayonix cases, since it doesn't seem to exist for that detector.