### PR TITLE
Fix for peak finding powder calculation

### DIFF
--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -355,9 +355,6 @@ class PeakFinder:
         """
         Summarize results and write to peakfinding.summary file.
         """
-        # debug
-        print(f"rank {self.rank} has powder_hits shape: {self.powder_hits.shape}")
-
         # grab summary stats
         self.n_hits_per_rank = self.comm.gather(self.n_hits, root=0)
         self.n_hits_total = self.comm.reduce(self.n_hits, MPI.SUM)

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -118,7 +118,7 @@ class PeakFinder:
                                          atot_thr=self.atot_thr,
                                          son_min=self.son_min)
         self.n_hits = 0
-        self.powder_hits, self.powder_misses = None, None
+        self.powder_hits, self.powder_misses = np.zeros(self.psi.det.shape()), np.zeros(self.psi.det.shape())
 
     def set_up_cxi(self, tag=''):
         """
@@ -250,10 +250,8 @@ class PeakFinder:
             outh5[f'/LCLS/{key}'].resize((self.n_hits,))
 
         # add powders and mask, reshaping to match crystfel conventions
-        if self.powder_hits is not None:
-            outh5["/entry_1/data_1/powderHitsRank"][:] = self.powder_hits.reshape(-1, self.powder_hits.shape[-1])
-        if self.powder_misses is not None:
-            outh5["/entry_1/data_1/powderMissesRank"][:] = self.powder_misses.reshape(-1, self.powder_misses.shape[-1])
+        outh5["/entry_1/data_1/powderHitsRank"][:] = self.powder_hits.reshape(-1, self.powder_hits.shape[-1])
+        outh5["/entry_1/data_1/powderMissesRank"][:] = self.powder_misses.reshape(-1, self.powder_misses.shape[-1])
         outh5["/entry_1/data_1/mask"][:] = (1-self.mask).reshape(-1, self.mask.shape[-1]) # crystfel expects inverted values
 
         outh5.close()
@@ -357,6 +355,9 @@ class PeakFinder:
         """
         Summarize results and write to peakfinding.summary file.
         """
+        # debug
+        print(f"rank {self.rank} has powder_hits shape: {self.powder_hits.shape}")
+
         # grab summary stats
         self.n_hits_per_rank = self.comm.gather(self.n_hits, root=0)
         self.n_hits_total = self.comm.reduce(self.n_hits, MPI.SUM)


### PR DESCRIPTION
This fix ensures that all ranks will have an array of the correct dimensions (rather than None if no hits are found) to avoid errors when gathering the individual powders for the final calculation. 

Unfortunately a separate error will still arise if the task is distributed across too many ranks:
```  
File "/cds/home/a/apeck/btx/btx/processing/peak_finder.py", line 362, in summarize
    powder_hits_all = np.max(np.array(self.comm.gather(self.powder_hits, root=0)), axis=0)
  File "mpi4py/MPI/Comm.pyx", line 1578, in mpi4py.MPI.Comm.gather
  File "mpi4py/MPI/msgpickle.pxi", line 773, in mpi4py.MPI.PyMPI_gather
  File "mpi4py/MPI/msgpickle.pxi", line 778, in mpi4py.MPI.PyMPI_gather
  File "mpi4py/MPI/msgpickle.pxi", line 191, in mpi4py.MPI.pickle_allocv
  File "mpi4py/MPI/msgpickle.pxi", line 182, in mpi4py.MPI.pickle_alloc
SystemError: Negative size passed to PyBytes_FromStringAndSize
```
From poking around Stack Overflow, it appears this may be a memory issue. Reducing the number of ranks from 128 to 24 resolved the issue.