### PR TITLE
`TMP_EXE` environment variable only set if submitted by ` ps-data` group member.

### DIFF
--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -63,7 +63,7 @@ class Indexer:
         if "TMP_EXE" in os.environ:
             self.tmp_exe = os.environ['TMP_EXE']
         else:
-            self.tmp_exe = os.path.join(self.taskdir ,f'r{self.run:04}/index_r{self.run:04}_{str(uuid.uuid4())}.sh')
+            self.tmp_exe = os.path.join(self.taskdir ,f'r{self.run:04}/index_r{self.run:04}.sh')
         self.peakfinding_summary = os.path.join(self.taskdir ,f'r{self.run:04}/peakfinding{self.tag_cxi}.summary')
         self.indexing_summary = os.path.join(self.taskdir ,f'r{self.run:04}/indexing_{self.tag}.summary')
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -1,8 +1,8 @@
-import numpy as np
 import argparse
 import os
-import subprocess
 import requests
+import subprocess
+import uuid
 
 class Indexer:
     
@@ -63,7 +63,7 @@ class Indexer:
         if "TMP_EXE" in os.environ:
             self.tmp_exe = os.environ['TMP_EXE']
         else:
-            self.tmp_exe = os.path.join(self.taskdir ,f'r{self.run:04}/index_r{self.run:04}.sh')
+            self.tmp_exe = os.path.join(self.taskdir ,f'r{self.run:04}/index_r{self.run:04}_{str(uuid.uuid4())}.sh')
         self.peakfinding_summary = os.path.join(self.taskdir ,f'r{self.run:04}/peakfinding{self.tag_cxi}.summary')
         self.indexing_summary = os.path.join(self.taskdir ,f'r{self.run:04}/indexing_{self.tag}.summary')
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import requests
 import subprocess
-import uuid
 
 class Indexer:
     

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -108,8 +108,11 @@ MAIN_PY="/cds/sw/ds/ana/conda1/inst/envs/ana-4.0.38-py3/bin/mpirun ${MAIN_PY}"
 else
 MAIN_PY="/cds/sw/ds/ana/conda1/inst/envs/ana-4.0.38-py3/bin/python ${MAIN_PY}"
 fi
-UUID=$(cat /proc/sys/kernel/random/uuid)
-TMP_EXE="${SCRIPT_DIR}/task_${UUID}.sh"
+# Define the TMP_EXE environment variable if submitted by a user belonging to ps-data
+if [ `groups | grep "ps-data"` != '' ]; then
+  UUID=$(cat /proc/sys/kernel/random/uuid)
+  TMP_EXE="${SCRIPT_DIR}/task_${UUID}.sh"
+fi
 
 #Submit to SLURM
 sbatch << EOF


### PR DESCRIPTION
Only add to the script directory if the executing user belongs to ps-data. 
Other users do not have write access there.

We might want to get rid of this environment variable and deal with temporary executables files directly within btx going forward.

Closes #172 