### PR TITLE
yaml for droplet-on-demand beamtime mfxx49820

### DIFF
--- a/tutorial/mfxx49820.yaml
+++ b/tutorial/mfxx49820.yaml
@@ -1,0 +1,73 @@
+setup:
+  queue: ffbh3q
+  root_dir: '/cds/data/psdm/mfx/mfxx49820/scratch/btx/'
+  exp: 'mfxx49820'
+  run: 6
+  det_type: 'epix10k2M'
+
+fetch_mask:
+  dataset: '/data/data'
+
+fetch_geom:
+
+build_mask:
+  thresholds: -10 5000
+  n_images: 20
+  n_edge: 1
+  combine: True
+
+run_analysis:
+  max_events: -1
+
+opt_geom:
+  n_iterations: 5
+  n_peaks: 3
+  threshold: 1000000
+
+find_peaks:
+  tag: ''
+  psana_mask: False
+  min_peaks: 10
+  max_peaks: 2048
+  npix_min: 2
+  npix_max: 30
+  amax_thr: 40.
+  atot_thr: 180.
+  son_min: 10.0
+  peak_rank: 3
+  r0: 3.0
+  dr: 2.0
+  nsigm: 10.0
+
+index:
+  tag: 'sample1'
+  int_radius: '3,4,5'
+  methods: 'mosflm'
+  tolerance: '5,5,5,1.5'
+  no_revalidate: True
+  multi: True
+  profile: True
+
+stream_analysis:
+  tag: 'sample1'
+
+determine_cell:
+  tag: 'sample1'
+
+merge:
+  tag: 'sample1'
+  symmetry: '2/m_uab'
+  iterations: 1
+  model: 'unity'
+  foms: 'CCstar Rsplit'
+  nshells: 10
+  highres: 2.5
+
+refine_center:
+  runs: 6 6
+  dx: -1 1 3
+  dy: -1 1 3
+ 
+refine_distance:
+  runs: 6 6 1
+  dz: -0.02 0.02 5


### PR DESCRIPTION
A yaml file has been added for experiment mfxx49820, assuming use of the epix10k2M detector and the ffb nodes for analysis. 