### PR TITLE
Alternative calibration directory.

### DIFF
--- a/btx/interfaces/psana_interface.py
+++ b/btx/interfaces/psana_interface.py
@@ -1,6 +1,6 @@
 import numpy as np
 import psana
-from psana import DataSource
+from psana import setOption
 from psana import EventId
 from PSCalib.GeometryAccess import GeometryAccess
 
@@ -8,7 +8,7 @@ class PsanaInterface:
 
     def __init__(self, exp, run, det_type,
                  event_receiver=None, event_code=None, event_logic=True,
-                 ffb_mode=False, track_timestamps=False):
+                 ffb_mode=False, track_timestamps=False, calibdir=None):
         self.exp = exp # experiment name, str
         self.run = run # run number, int
         self.det_type = det_type # detector name, str
@@ -17,10 +17,10 @@ class PsanaInterface:
         self.event_receiver = event_receiver # 'evr0' or 'evr1', str
         self.event_code = event_code # event code, int
         self.event_logic = event_logic # bool, if True, retain events with event_code; if False, keep all other events
-        self.set_up(det_type, ffb_mode)
+        self.set_up(det_type, ffb_mode, calibdir)
         self.counter = 0
 
-    def set_up(self, det_type, ffb_mode):
+    def set_up(self, det_type, ffb_mode, calibdir=None):
         """
         Instantiate DataSource and Detector objects; use the run 
         functionality to retrieve all psana.EventTimes.
@@ -31,6 +31,8 @@ class PsanaInterface:
             detector type, e.g. epix10k2M or jungfrau4M
         ffb_mode : bool
             if True, set up in an FFB-compatible style
+        calibdir: str
+            directory to alternative calibration files
         """
         ds_args=f'exp={self.exp}:run={self.run}:idx'
         if ffb_mode:
@@ -43,6 +45,8 @@ class PsanaInterface:
         self.runner = next(self.ds.runs())
         self.times = self.runner.times()
         self.max_events = len(self.times)
+        if calibdir is not None:
+            setOption('psana.calib_dir', calibdir)
         self._calib_data_available()
 
     def _calib_data_available(self):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -135,7 +135,8 @@ def find_peaks(config):
                     event_receiver=setup.get('event_receiver'), event_code=setup.get('event_code'), event_logic=setup.get('event_logic'),
                     tag=task.tag, mask=mask_file, psana_mask=task.psana_mask, min_peaks=task.min_peaks, max_peaks=task.max_peaks,
                     npix_min=task.npix_min, npix_max=task.npix_max, amax_thr=task.amax_thr, atot_thr=task.atot_thr, 
-                    son_min=task.son_min, peak_rank=task.peak_rank, r0=task.r0, dr=task.dr, nsigm=task.nsigm)
+                    son_min=task.son_min, peak_rank=task.peak_rank, r0=task.r0, dr=task.dr, nsigm=task.nsigm,
+                    calibdir=task.get('calibdir'))
     logger.debug(f'Performing peak finding for run {setup.run} of {setup.exp}...')
     pf.find_peaks()
     pf.curate_cxi()


### PR DESCRIPTION
Added the option to use an alternative calibration directory for `find_peaks` by setting an optional `calibdir` argument in the input configuration file.

Succesfully tested.