### PR TITLE
Fix to when `find_peaks` due to `eBeam` detector not reporting per-event photon energy

### DIFF
--- a/btx/interfaces/psana_interface.py
+++ b/btx/interfaces/psana_interface.py
@@ -109,8 +109,11 @@ class PsanaInterface:
         """
         ebeam = psana.Detector('EBeam')
         photon_energy = ebeam.get(evt).ebeamPhotonEnergy()
-        lambda_m =  1.23984197386209e-06 / photon_energy # convert to meters using e=hc/lambda
-        return lambda_m * 1e10
+        if np.isinf(photon_energy):
+            return self.get_wavelength()
+        else:
+            lambda_m =  1.23984197386209e-06 / photon_energy # convert to meters using e=hc/lambda
+            return lambda_m * 1e10
 
     def estimate_distance(self):
         """


### PR DESCRIPTION
added bypass for when the photon energy reported by the ebeam detector is infinite.