### PR TITLE
created `clean_up` task and `wrapup_sample` DAG

### DIFF
--- a/dags/wrapup_sample.py
+++ b/dags/wrapup_sample.py
@@ -28,5 +28,9 @@ solve = JIDSlurmOperator( task_id=task_id, dag=dag, run_at='SRCF_FFB')
 task_id='elog_display'
 elog_display = JIDSlurmOperator(task_id=task_id, dag=dag, run_at='SRCF_FFB')
 
+task_id='clean_up'
+clean_up = JIDSlurmOperator(task_id=task_id, dag=dag, run_at='SRCF_FFB')
+
 # Draw the DAG
 stream_analysis >> merge >> solve >> elog_display
+stream_analysis >> clean_up

--- a/dags/wrapup_sample.py
+++ b/dags/wrapup_sample.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+import os
+from airflow import DAG
+from plugins.jid import JIDSlurmOperator
+
+# DAG SETUP
+description='BTX wrap-up sample DAG'
+dag_name = os.path.splitext(os.path.basename(__file__))[0]
+
+dag = DAG(
+    dag_name,
+    start_date=datetime( 2022,4,1 ),
+    schedule_interval=None,
+    description=description,
+  )
+
+
+# Tasks SETUP
+task_id='stream_analysis'
+stream_analysis = JIDSlurmOperator( task_id=task_id, dag=dag, run_at='SRCF_FFB')
+
+task_id='merge'
+merge = JIDSlurmOperator( task_id=task_id, dag=dag, run_at='SRCF_FFB')
+
+task_id='solve'
+solve = JIDSlurmOperator( task_id=task_id, dag=dag, run_at='SRCF_FFB')
+
+task_id='elog_display'
+elog_display = JIDSlurmOperator(task_id=task_id, dag=dag, run_at='SRCF_FFB')
+
+# Draw the DAG
+stream_analysis >> merge >> solve >> elog_display

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -185,7 +185,7 @@ def stream_analysis(config):
         write_cell_file(st.cell_params, os.path.join(celldir, f"{task.tag}.cell"), input_file=setup.get('cell'))
         logger.info(f'Wrote updated CrystFEL cell file to {celldir}')
         stream_cat = os.path.join(taskdir, f"{task.tag}.stream")
-        os.system(f"cat {stream_files} >> {stream_cat}")
+        os.system(f"cat {stream_files} > {stream_cat}")
         logger.info(f'Concatenated all stream files to {task.tag}.stream')
         logger.debug('Done!')
 
@@ -312,4 +312,12 @@ def elog_display(config):
     logger.info(f'Updating the reports in the eLog summary tab.')
     eli = eLogInterface(setup)
     eli.update_summary()
+    logger.debug('Done!')
+
+def clean_up(config):
+    setup = config.setup
+    task = config.clean_up
+    taskdir = os.path.join(setup.root_dir, 'index')
+    if os.path.isdir(taskdir):
+        os.system(f"rm -f {taskdir}/r*/*{task.tag}.cxi")
     logger.debug('Done!')


### PR DESCRIPTION
Three modifications were done:
- `stream_analysis` task now overwrites instead of appending to the sample stream file.
- `clean_up` task was tested succesfully. It deletes all `{root_dir}/index/r*/*{tag}.cxi` files.
- the `wrapup_sample` DAG will be tested after merging to main.