### PR TITLE
Workaround for calculating powders to avoid memory error

### DIFF
--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -157,7 +157,7 @@ class PeakFinder:
                                         maxshape=(None, dim0, dim1),dtype=np.float32)
         data_1.attrs["axes"] = "experiment_identifier"
         
-        for key in ['powderHits', 'powderMisses', 'mask', 'powderHitsRank', 'powderMissesRank']:
+        for key in ['powderHits', 'powderMisses', 'mask']:
             entry_1.create_dataset(f'/entry_1/data_1/{key}', (dim0, dim1), chunks=(dim0, dim1), maxshape=(dim0, dim1), dtype=float)
                 
         # peak-related keys


### PR DESCRIPTION
This addresses Issue #171. The powder hits and misses arrays are now computed after the individual CXI files are finalized rather than using mpi4py's gather function to avoid a memory error when many ranks are in use. The updated script was tested on a Rayonix dataset with 128 ranks. 

A minor change was also made to the `visualize_hits` function to make it consistent with its docstring.