### PR TITLE
added ability to retrieve the pulse energy for each event.

### DIFF
--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -127,6 +127,9 @@ class PsanaInterface:
         ----------
         evt : psana.Event object
             individual psana event
+        mode : str, optional
+            whether to only return the energy 'before' or 'after' gas attenuation,
+            or if 'None' the average of the two.
 
         Returns
         -------

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -123,6 +123,8 @@ class PsanaInterface:
          - https://confluence.slac.stanford.edu/display/PSDM/New+XTCAV+Documentation
          - https://www-ssrl.slac.stanford.edu/lcls/technotes/LCLS-TN-09-5.pdf
 
+        Note: the pulse energy is equal to the photon energy times the number of photons in the pulse.
+
         Parameters
         ----------
         evt : psana.Event object
@@ -133,6 +135,8 @@ class PsanaInterface:
 
         Returns
         -------
+        gas_detector_energy: float
+            Beam energy in mJ
 
         """
         gdet = evt.get(psana.Bld.BldDataFEEGasDetEnergyV1, psana.Source())

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -115,6 +115,34 @@ class PsanaInterface:
             lambda_m =  1.23984197386209e-06 / photon_energy # convert to meters using e=hc/lambda
             return lambda_m * 1e10
 
+    def get_fee_gas_detector_energy_mJ_evt(self, evt, mode=None):
+        """
+        Retrieve pulse energy measured by Front End Enclosure Gas Detectors.
+        For more information:
+         - https://pswww.slac.stanford.edu/swdoc/releases/ana-current/psana-ref/html/psana/#class-psana-bld-blddatafeegasdetenergyv1
+         - https://confluence.slac.stanford.edu/display/PSDM/New+XTCAV+Documentation
+         - https://www-ssrl.slac.stanford.edu/lcls/technotes/LCLS-TN-09-5.pdf
+
+        Parameters
+        ----------
+        evt : psana.Event object
+            individual psana event
+
+        Returns
+        -------
+
+        """
+        gdet = evt.get(psana.Bld.BldDataFEEGasDetEnergyV1, psana.Source())
+        if gdet is not None:
+            gdet_before_attenuation = 0.5 * (gdet.f_11_ENRC() + gdet.f_12_ENRC())
+            gdet_after_attenuation  = 0.5 * (gdet.f_21_ENRC() + gdet.f_22_ENRC())
+            if( mode == 'before' ):
+                return gdet_before_attenuation
+            elif( mode == 'after' ):
+                return gdet_after_attenuation
+            else:
+                return 0.5 * (gdet_before_attenuation + gdet_after_attenuation)
+
     def estimate_distance(self):
         """
         Retrieve an estimate of the detector distance in mm.


### PR DESCRIPTION
Needs to be tested.

A draft version run in a notebook yielded the following for cxilx5920:

![image](https://user-images.githubusercontent.com/4610338/199870463-f1ef6784-f864-4693-974b-efae847c3f54.png)
![image](https://user-images.githubusercontent.com/4610338/199870472-18706810-69bc-49fe-9980-ab3e9f50c556.png)
![image](https://user-images.githubusercontent.com/4610338/199870489-6f958fe8-80b4-49eb-945f-bcf68635b827.png)

Draft code:
```python
def gdet_energy(exp, run, det_type='jungfrau4M', 
                gdet_before_att=None, gdet_after_att=None,
                nevt_max=-1, nevt_mod=100):
    psi = PsanaInterface(exp, run, det_type)
    if gdet_before_att is None:
        gdet_before_att = []
    if gdet_after_att is None:
        gdet_after_att = []
    if(nevt_max<0):
        nevt_max = len(psi.times)
    nevt=0
    for t in tqdm(psi.times):
        if(nevt>nevt_max):
            break
        if(nevt % nevt_mod == 0):
            evt = psi.runner.event(t)
            gdet = evt.get(psana.Bld.BldDataFEEGasDetEnergyV1, psana.Source())
            if gdet is not None:
                gdet_before_att.append(0.5*(gdet.f_11_ENRC()+gdet.f_12_ENRC()))
                gdet_after_att.append(0.5*(gdet.f_21_ENRC()+gdet.f_22_ENRC()))
        nevt += 1
    return gdet_before_att, gdet_after_att
```
```python
exp='cxilx5920'
dark_runs = [1,2,6,22,42,54,55,68,77,104,105,110,116,122,140,153,159]
gdet_before_att = None
gdet_after_att = None
E_mean = []
E_mean_run = []
for run in np.arange(1,159,10):
    if run not in dark_runs:
        gdet_before_att, gdet_after_att = gdet_energy(exp, run, 
                                                  gdet_before_att=gdet_before_att, 
                                                  gdet_after_att=gdet_after_att)
        print(f'Run # {run} | <E> = {np.mean(gdet_after_att):.2f} mJ ')
        E_mean_run.append(run)
        E_mean.append(np.mean(gdet_after_att))
```