### PR TITLE
Adjusting `StreamInterface` to avoid memory error in plotting peakogram

### DIFF
--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -63,7 +63,7 @@ class JobScheduler:
         if "crystfel" in dependencies:
             dep_paths += "export PATH=/cds/sw/package/crystfel/crystfel-dev/bin:$PATH\n"
         if "ccp4" in dependencies:
-            dep_paths += "source /cds/sw/package/ccp4/ccp4-7.0/setup-scripts/ccp4.setup-sh\n"
+            dep_paths += "source /cds/sw/package/ccp4/ccp4-8.0/bin/ccp4.setup-sh\n"
         if "phenix" in dependencies:
             dep_paths += "source /cds/sw/package/phenix-1.13-2998/phenix_env.sh\n"
         if "xds" in dependencies:

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -13,13 +13,15 @@ class StreamInterface:
     def __init__(self, input_files, cell_only=False):
         self.cell_only = cell_only # bool, if True only extract unit cell params
         self.input_files = input_files # list of stream file(s)
-        self.stream_data, self.file_limits = self.read_all_streams(self.input_files)
-        self.compute_mean_cell()
+        self.stream_data, self.file_limits_cell, self.file_limits_refn = self.read_all_streams(self.input_files)
+        if self.rank == 0:
+            self.compute_cell()
+            if not self.cell_only:
+                self.compute_resolution()
     
     def read_all_streams(self, input_files):
         """
-        Read stream file(s), with files distributed across multiple ranks
-        if available.
+        Read stream file(s), distributing files across ranks if available.
         
         Parameters
         ----------
@@ -28,41 +30,52 @@ class StreamInterface:
         
         Returns
         -------
-        stream_data : numpy.ndarray, shape (n_refl,16) or (n_refl,8)
-            [crystal_num,a,b,c,alpha,beta,gamma,h,k,l,I,sigma(I),peak,background,res]
-            or [crystal_num,a,b,c,alpha,beta,gamma] if self.cell_only=False        
+        stream_data : dict
+            cell parameters and (if not self.cell_only) reflection information
         file_limits : numpy.ndarray, shape (n_files)
             indices of stream_data's first dimension that indicate start/end of each file
         """
         # processing all files given to each rank
-        stream_data_rank = []
+        stream_data_rank = {}
+        file_limits_rank_cell = []
+        file_limits_rank_refn = []
+        
         input_sel = self.distribute_streams(input_files) 
         if len(input_sel) != 0:
             for ifile in input_sel:
                 single_stream_data = self.read_stream(ifile)
-                if len(single_stream_data) == 0: # no crystals in stream file
-                    if self.cell_only: 
-                        single_stream_data = np.empty((0,8))
-                    else: 
-                        single_stream_data = np.empty((0,16))
-                stream_data_rank.append(single_stream_data)
-            file_limits_rank = np.array([sdr.shape[0] for sdr in stream_data_rank])
-            stream_data_rank = np.vstack(stream_data_rank)  
-        else: # no files assigned to this rank
-            if self.cell_only:
-                stream_data_rank = np.empty((0,8))
-            else:
-                stream_data_rank = np.empty((0,16))
-            file_limits_rank = np.empty(0)
-        
+                file_limits_rank_cell.append(len(single_stream_data['a']))
+                if not self.cell_only:
+                    file_limits_rank_refn.append(len(single_stream_data['h']))
+                if len(stream_data_rank) == 0:
+                    stream_data_rank = single_stream_data
+                else:
+                    [stream_data_rank[key].extend(single_stream_data[key]) for key in stream_data_rank.keys()]
+
         # amassing files from different ranks
-        stream_data = self.comm.gather(stream_data_rank, root=0)
-        file_limits = self.comm.gather(file_limits_rank, root=0)
+        stream_data = {}
+        for key in stream_data_rank.keys():
+            stream_data[key] = self.comm.gather(stream_data_rank[key], root=0)
+        file_limits_cell = self.comm.gather(file_limits_rank_cell, root=0)
+        file_limits_refn = self.comm.gather(file_limits_rank_refn, root=0)
+        
         if self.rank == 0:
-            stream_data = np.vstack(stream_data)
-            file_limits = np.concatenate(file_limits)
-            file_limits = np.append(np.array([0]), np.cumsum(file_limits))
-        return stream_data, file_limits
+            for key in stream_data.keys():
+                if key == 'n_crystal':
+                    stream_data[key] = [np.array(arr) for arr in stream_data[key]]
+                    for narr in range(1, len(stream_data[key])):
+                        stream_data[key][narr] += stream_data[key][narr-1][-1]+1
+                stream_data[key] = np.concatenate(np.array(stream_data[key], dtype=object))
+                if key in ['n_crystal','n_chunk', 'n_crystal_cell', 'h', 'k', 'l']:
+                    stream_data[key] = stream_data[key].astype(int)
+                else:
+                    stream_data[key] = stream_data[key].astype(float)
+                if key in ['a','b','c']:
+                    stream_data[key] *= 10.0 # convert from nm to Angstrom
+            file_limits_cell = np.cumsum(np.append(np.array([0]), np.concatenate(np.array(file_limits_cell, dtype=object))))
+            file_limits_refn = np.cumsum(np.append(np.array([0]), np.concatenate(np.array(file_limits_refn, dtype=object))))
+
+        return stream_data, file_limits_cell, file_limits_refn
         
     def distribute_streams(self, input_files):
         """
@@ -82,6 +95,7 @@ class StreamInterface:
         self.comm = MPI.COMM_WORLD
         self.rank = self.comm.Get_rank()
         self.size = self.comm.Get_size() 
+        self.n_crystal = -1
         
         # divvy up files
         n_files = len(input_files)
@@ -94,7 +108,7 @@ class StreamInterface:
         split_indices = np.append(np.array([0]), np.cumsum(split_indices)).astype(int) 
         return input_files[split_indices[self.rank]:split_indices[self.rank+1]]
     
-    def read_stream(self, input_file):
+    def read_stream(self, input_file=None):
         """
         Read a single stream file. Function possibly adapted from CrystFEL.
         
@@ -105,175 +119,96 @@ class StreamInterface:
         
         Returns
         -------
-        single_stream_data : numpy.ndarray, shape (n_refl,14) or (n_refl,7)
-            [crystal_num,a,b,c,alpha,beta,gamma,h,k,l,I,sigma(I),peak,background,res]
-            or [crystal_num,a,b,c,alpha,beta,gamma] if self.cell_only=False
+        single_stream_data : dict
+            cell parameters and (if not self.cell_only) reflection information
         """
-        single_stream_data = []
-        n_cryst, n_chunk = -1, -1
-        in_refl = False
+        # set up storage arrays
+        single_stream_data = {}
+        keys = ['a','b','c','alpha','beta','gamma','n_crystal','n_chunk', 'n_crystal_cell']
+        if not self.cell_only:
+            keys.extend(['h','k','l','sumI','sigI','maxI'])
+        for key in keys:
+            single_stream_data[key] = []
+        
+        # parse stream file
+        if input_file is not None:
+            n_chunk = -1
+            n_crystal_cell = -1
+            in_refl = False
 
-        f = open(input_file)
-        for lc,line in enumerate(f):
-            if line.find("Begin chunk") != -1:
-                n_chunk += 1
-                if in_refl:
-                    in_refl = False
-                    print(f"Warning! Line {lc} associated with chunk {n_chunk} is problematic: {line}")
-            
-            if line.find("Cell parameters") != -1:
-                cell = line.split()[2:5] + line.split()[6:9]
-                cell = np.array(cell).astype(float)
-                n_cryst+=1
+            f = open(input_file)
+            for lc,line in enumerate(f):
+                if line.find("Begin chunk") != -1:
+                    n_chunk += 1
+                    if in_refl:
+                        in_refl = False
+                        print(f"Warning! Line {lc} associated with chunk {n_chunk} is problematic: {line}")
+                    #single_stream_data['n_chunk'].append(n_chunk)
 
-                if self.cell_only:
-                    single_stream_data.append(np.concatenate((np.array([n_chunk, n_cryst]), cell)))
-
-            if not self.cell_only:
-                if line.find("Reflections measured after indexing") != -1:
-                    in_refl = True
-                    continue
-
-                if line.find("End of reflections") != -1:
-                    in_refl = False
-                    continue
-
-                if in_refl:
-                    if line.find("h    k    l") == -1:
-                        try:
-                            reflection = np.array(line.split()[:7]).astype(float)
-                            single_stream_data.append(np.concatenate((np.array([n_chunk, n_cryst]), cell, reflection, np.array([-1]))))
-                        except ValueError:
-                            print(f"Couldn't parse line {lc}: {line}")
+                if line.find("Cell parameters") != -1:
+                    cell = line.split()[2:5] + line.split()[6:9]
+                    for ival,param in enumerate(['a','b','c','alpha','beta','gamma']):
+                        single_stream_data[param].append(float(cell[ival]))
+                    self.n_crystal+=1
+                    n_crystal_cell += 1
+                    single_stream_data['n_crystal_cell'].append(n_crystal_cell)
+                    single_stream_data['n_chunk'].append(n_chunk)
+                    if self.cell_only:
+                        single_stream_data['n_crystal'].append(self.n_crystal)
+                        
+                if not self.cell_only:
+                    if line.find("Reflections measured after indexing") != -1:
+                        in_refl = True
                         continue
 
-        f.close()
+                    if line.find("End of reflections") != -1:
+                        in_refl = False
+                        continue
 
-        single_stream_data = np.array(single_stream_data)
-        if not self.cell_only:
-            if len(single_stream_data) == 0:
-                print(f"Warning: no indexed reflections found in {input_file}!")
-            else:
-                single_stream_data[:,-1] = compute_resolution(single_stream_data[:,2:8], single_stream_data[:,8:11])
+                    if in_refl:
+                        if line.find("h    k    l") == -1:
+                            try:
+                                reflection = [val for val in line.split()]
+                                for ival,param in enumerate(['h','k','l','sumI','sigI','maxI']):
+                                    if ival < 3:
+                                        single_stream_data[param].append(int(reflection[ival]))
+                                    else:
+                                        single_stream_data[param].append(float(reflection[ival]))
+                                single_stream_data['n_crystal'].append(self.n_crystal)
+                            except ValueError:
+                                print(f"Couldn't parse line {lc}: {line}")
+                            continue
+            f.close()
+
+            if not self.cell_only:
+                if len(single_stream_data['h']) == 0:
+                    print(f"Warning: no indexed reflections found in {input_file}!")
                 
         return single_stream_data
     
-    def compute_mean_cell(self):
+    def compute_cell(self):
         """ 
-        Compute the mean unit cell parameters: [a,b,c,alpha,beta,gamma] in A/degrees. 
-        Since the crystal number column (self.stream_data[:,1]) resets to 0 for each
-        input stream file, a self.ncryst variable is also created to track the crystal 
-        index, ignoring which file each data entry comes from.
+        Compute the mean and std. dev. of the unit cell parameters in A/degrees. 
         """
-
-        ncryst = self.stream_data[:,1].copy()
-        next_cryst_idx = np.where(np.diff(ncryst)<0)[0] + 1
-        next_cryst_idx = np.append(next_cryst_idx, np.array(len(ncryst)))
-        ncryst_to_add = ncryst[next_cryst_idx-1]
-
-        for idx in range(len(next_cryst_idx)-1):
-            ncryst[next_cryst_idx[idx]:] += ncryst_to_add[idx] + 1
-        self.ncryst=ncryst
-
-        unq_vals, self.unq_inds = np.unique(self.ncryst, return_index=True)
-        unq_cells = self.stream_data[self.unq_inds,2:8]
-        self.cell_params = np.mean(unq_cells, axis=0)
-        self.cell_params[:3]*=10 # convert unit cell from nm to Angstrom    
-        self.cell_params_std = np.std(unq_cells, axis=0)
-        self.cell_params_std[:3]*=10
+        keys = ['a','b','c','alpha','beta','gamma']
+        self.cell_params = np.array([np.mean(self.stream_data[key]) for key in keys])
+        self.cell_params_std = np.array([np.std(self.stream_data[key]) for key in keys])
+        
+    def compute_resolution(self):
+        """
+        Compute the resolution in inverse Angstrom of each reflection.
+        """
+        cell = self.get_cell_parameters()
+        hkl = np.array([self.stream_data[key] for key in ['h','k','l']]).T
+        cindex, ccounts = np.unique(self.stream_data['n_crystal'], return_counts=True)
+        cell = np.repeat(cell, ccounts, axis=0)
+        self.stream_data['d'] = compute_resolution(cell, hkl)
         
     def get_cell_parameters(self):
         """ Retrieve unit cell parameters: [a,b,c,alpha,beta,gamma] in A/degrees. """
-        return self.stream_data[:,2:8] * np.array([10.,10.,10.,1,1,1])
-    
-    def get_peak_res(self):
-        """ Retrieve resolution of peaks in 1/Angstrom from self.stream_data. """
-        if self.cell_only:
-            print("Reflections were not extracted")
-        else:
-            return self.stream_data[:,-1]
-    
-    def get_peak_sumI(self):
-        """ Retrieve summed intensity of peaks from self.stream_data. """
-        if self.cell_only:
-            print("Reflections were not extracted")
-        else:
-            return self.stream_data[:,-5]
+        keys = ['a','b','c','alpha','beta','gamma']
+        return np.array([self.stream_data[key] for key in keys]).T
 
-    def get_peak_maxI(self):
-        """ Retrieve max intensity of peaks from self.stream_data. """
-        if self.cell_only:
-            print("Reflections were not extracted")
-        else:
-            return self.stream_data[:,-3]
-    
-    def get_peak_sigI(self):
-        """ Retrieve peaks' standard deviations from self.stream_data. """
-        if self.cell_only:
-            print("Reflections were not extracted")
-        else:
-            return self.stream_data[:,-4]
-    
-    def plot_peakogram(self, output=None, plot_Iogram=False):
-        """
-        Generate a peakogram of the stream data.
-        
-        Parameters
-        ----------
-        output : string, default=None
-            if supplied, path for saving png of peakogram
-        plot_Iogram : boolean, default=False
-            if True, plot integrated rather than max intensities in the peakogram
-        """
-        if self.cell_only:
-            print("Cannot plot peakogram because only cell parameters were extracted")
-            return
-              
-        peak_res = self.get_peak_res()
-        peak_sig = self.get_peak_sigI()
-        if not plot_Iogram:
-            peak_sum = self.get_peak_sumI()
-            peak_max = self.get_peak_maxI()
-            xlabel, ylabel = "sum", "max"
-        # if Iogram, swap peak_sum and peak_max
-        else:
-            peak_sum = self.get_peak_maxI()
-            peak_max = self.get_peak_sumI()
-            xlabel, ylabel = "max", "sum"
-
-        figsize = 8
-        peakogram_bins = [500, 500]
-
-        fig = plt.figure(figsize=(figsize, figsize), dpi=300)
-        gs = fig.add_gridspec(2, 2)
-
-        irow = 0
-        ax1 = fig.add_subplot(gs[irow, 0:])
-        ax1.set_title(f'Peakogram ({peak_res.shape[0]} reflections)')
-
-        x, y = peak_res[peak_max>0], np.log10(peak_max[peak_max>0]) # can be negative for Iogram
-        H, xedges, yedges = np.histogram2d(y, x, bins=peakogram_bins)
-        im = ax1.pcolormesh(yedges, xedges, H, cmap='gray', norm=LogNorm())
-        plt.colorbar(im)
-        ax1.set_xlabel("1/d (${\mathrm{\AA}}$$^{-1}$)")
-        ax1.set_ylabel(f"log(peak intensity) - {ylabel}")
-
-        irow += 1
-        ax2 = fig.add_subplot(gs[irow, 0])
-        im = ax2.hexbin(peak_sum, peak_max, gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')
-
-        ax2.set_xlabel(f'{xlabel} in peak')
-        ax2.set_ylabel(f'{ylabel} in peak')
-
-        ax3 = fig.add_subplot(gs[irow, 1])
-        im = ax3.hexbin(peak_sig, peak_max, gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')
-        ax3.set_xlabel('sig(I)')
-        ax3.set_yticks([])
-        plt.colorbar(im, label='No. reflections')
-        
-        if output is not None:
-            fig.savefig(output, dpi=300)
-    
     def plot_cell_parameters(self, output=None):
         """
         Plot histograms of the unit cell parameters, indicating the median
@@ -284,26 +219,73 @@ class StreamInterface:
         output : string, default=None
             if supplied, path for saving png of unit cell parameters
         """
+        cell = self.get_cell_parameters()
+        
         f, ((ax1,ax2,ax3),(ax4,ax5,ax6)) = plt.subplots(2,3,figsize=(12,5))
 
         labels = ["$a$", "$b$", "$c$", r"$\alpha$", r"$\beta$", r"$\gamma$"]
         for i,ax in enumerate([ax1,ax2,ax3,ax4,ax5,ax6]):
-            scale=10
-            if i>2: scale=1
-            vals = scale*self.stream_data[self.unq_inds,i+2] # first two cols are chunk,crystal
-            ax.hist(vals, bins=100, color='black')
-
-            if i<3:
-                ax.set_title(labels[i] + f"={np.mean(vals):.3f}" + " ${\mathrm{\AA}}$")
-            else:
-                ax.set_title(labels[i] + f"={np.mean(vals):.3f}" + "$^{\circ}$")
-            if i == 0 or i == 3:
+            ax.hist(cell[:,i], bins=100, color='black')
+            if i<3: 
+                ax.set_title(labels[i] + f"={np.mean(cell[:,i]):.3f}" + " ${\mathrm{\AA}}$")
+            else: 
+                ax.set_title(labels[i] + f"={np.mean(cell[:,i]):.3f}" + "$^{\circ}$")
+            if i == 0 or i == 3: 
                 ax.set_ylabel("No. crystals")
 
         f.subplots_adjust(hspace=0.4)
         
         if output is not None:
             f.savefig(output, dpi=300)
+            
+    def plot_peakogram(self, output=None):
+        """
+        Generate a peakogram of the stream data.
+        
+        Parameters
+        ----------
+        output : string, default=None
+            if supplied, path for saving png of peakogram
+        """
+        if self.cell_only:
+            print("Cannot plot peakogram because only cell parameters were extracted")
+            return
+        
+        figsize = 8
+        peakogram_bins = [500, 500]
+
+        fig = plt.figure(figsize=(figsize, figsize), dpi=300)
+        gs = fig.add_gridspec(2, 2)
+
+        irow = 0
+        ax1 = fig.add_subplot(gs[irow, 0:])
+        ax1.set_title(f"Peakogram ({len(self.stream_data['h'])} reflections)")
+
+        H, xedges, yedges = np.histogram2d(np.log10(self.stream_data['maxI']),
+                                           self.stream_data['d'],
+                                           bins=peakogram_bins)
+        im = ax1.pcolormesh(yedges, xedges, H, cmap='gray', norm=LogNorm())
+        plt.colorbar(im)
+        ax1.set_xlabel("1/d (${\mathrm{\AA}}$$^{-1}$)")
+        ax1.set_ylabel(f"log(peak intensity)")
+
+        irow += 1
+        ax2 = fig.add_subplot(gs[irow, 0])
+        im = ax2.hexbin(self.stream_data['sumI'], self.stream_data['maxI'], 
+                        gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')
+
+        ax2.set_xlabel(f'sum in peak')
+        ax2.set_ylabel(f'max in peak')
+
+        ax3 = fig.add_subplot(gs[irow, 1])
+        im = ax3.hexbin(self.stream_data['sigI'], self.stream_data['maxI'], 
+                        gridsize=100, mincnt=1, norm=LogNorm(), cmap='gray')
+        ax3.set_xlabel('sig(I)')
+        ax3.set_yticks([])
+        plt.colorbar(im, label='No. reflections')
+        
+        if output is not None:
+            fig.savefig(output, dpi=300)
 
     def report(self, update_url=None):
         """
@@ -326,90 +308,110 @@ class StreamInterface:
             labels = ["a", "b", "c", "alpha", "beta", "gamma"]
             elog_json = [{"key": labels[i], "value": f"{self.cell_params[i]:.3f} +/- {self.cell_params_std[i]:.3f}"} for i in range(len(labels))]
             requests.post(update_url, json=elog_json)
-    
-    def copy_from_stream(self, stream_file, indices, indices_chunks, output):
+            
+    def copy_from_stream(self, stream_file, chunk_indices, crystal_indices, output):
         """
         Add the indicated crystals from the input to the output stream.
+        There may be multiple crystals per chunk with multi-lattice indexing.
         
         Parameters
         ----------
         stream_file : str
             input stream file
-        indices : numpy.ndarray, 1d
-            indices of reflections (or crystals if self.cell_only) to retain
-        indices_chunks : numpy.ndarray, 1d
-            indices of chunks (crystals) to retain
+        chunk_indices : list
+            indices of the chunks from stream file to transfer
+        crystal_indices : list
+            indices of the crystals from stream file to transfer
         output : string
             path to output .stream file     
         """
 
         f_out = open(output, "a")
-        f_in = open(stream_file)
+        f_in = open(stream_file, "r")
         
         n_chunk = -1
-        hkl_counter = -1
-        in_header = True
-        current_chunk = False
+        n_crystal = -1
         in_refl = False
+        write = False
+        in_header = True
+        
+        target = [tuple((chunk_indices[i], crystal_indices[i])) for i in range(len(crystal_indices))]
 
-        for line in f_in:
+        for lc,line in enumerate(f_in):
 
             # copy header of stream file before first chunk begins
             if in_header:
                 if line.find("Indexing methods") != -1:
                     in_header = False
                 f_out.write(line)
-
-            # in chunk territory...
+                
+            # copy over relevant chunks
             if line.find("Begin chunk") != -1:
-                n_chunk += 1
-                if n_chunk in indices_chunks:
-                    current_chunk = True            
-            if current_chunk:
                 if in_refl:
-                    if (hkl_counter+1 in indices) or (self.cell_only):
-                    #if hkl_counter+1 in indices:
-                        if line.find("End of reflections") == -1:
-                            f_out.write(line)
-                else:
-                    f_out.write(line)
+                    in_refl = False
+                    print(f"Warning! Line {lc} associated with chunk {n_chunk} is problematic: {line}")
+                n_chunk += 1
+
+                #if (n_chunk in chunk_indices) and (n_crystal in crystal_indices):
+                if (n_chunk, n_crystal+1) in target:
+                    write = True    
+                    
+            if line.find("Cell parameters") != -1:
+                cell = line.split()[2:5] + line.split()[6:9]
+                if float(cell[2])*10.0 > 96 and write:
+                    print(stream_file, cell[2], n_chunk, n_crystal)
+                n_crystal += 1
+                
+                if (n_chunk, n_crystal+1) not in target:
+                    write = False
+
+            if write:
+                f_out.write(line)
+
             if line.find("End chunk") != -1:
-                current_chunk = False
-
-            # count reflections
-            if line.find("h    k    l") != -1:
-                in_refl = True
-                continue
-            if line.find("End of reflections") != -1:
-                if current_chunk:
-                    f_out.write(line)
-                in_refl = False
-            if in_refl:
-                hkl_counter += 1
-
+                write=False
+            
         f_in.close()
         f_out.close()
-        
-    def write_stream(self, all_indices, output):
+            
+    def write_stream(self, selection, output):
         """
-        Write a new stream file from a selection of crystals or reflections of
-        the original stream file(s).
+        Write a new stream file from a selection of crystals from the input
+        stream file(s).
         
         Parameters
         ----------
-        all_indices : numpy.ndarray, 1d
-            indices of self.stream_data to retain
+        selection : numpy.ndarray, 1d
+            indices of the crystals in self.stream_data to retain
         output : string
-            path to output .stream file     
+            path to output .stream file 
         """
         for nf,infile in enumerate(self.input_files):
-            lower, upper = self.file_limits[nf], self.file_limits[nf+1]
-            idx = np.where((all_indices>=lower) & (all_indices<upper))[0]
-            sel_indices = all_indices[idx] - lower
+            lower, upper = self.file_limits_cell[nf], self.file_limits_cell[nf+1]
+            idx = np.where((selection>=lower) & (selection<upper))[0]
+            sel_indices = selection[idx] - lower
             if len(sel_indices) > 0:
-                print(f"Copying {len(sel_indices)} chunks (or reflections) from file {infile}")
-                sel_chunks = np.unique(self.stream_data[all_indices[idx]][:,0]).astype(int)
-                self.copy_from_stream(infile, sel_indices, sel_chunks, output)
+                print(f"Copying {len(sel_indices)} crystals from file {infile}")
+                chunk_indices = self.stream_data['n_chunk'][lower:upper][sel_indices]
+                crystal_indices = self.stream_data['n_crystal_cell'][lower:upper][sel_indices]
+                self.copy_from_stream(infile, chunk_indices, crystal_indices, output)
+
+def read_cell_file(cell_file):
+    """
+    Extract cell parameters from a CrystFEL cell file.
+    
+    Parameters
+    ----------
+    cell_file : str
+        CrystFEL cell file
+        
+    Returns
+    -------
+    array of cell parameters: [a,b,c,alpha,beta,gamma] in Angstrom/degrees
+    """
+    with open(cell_file, "r") as f:
+        params = f.readlines()[-6:]
+        return [float(line.split("=")[1].split()[0]) for line in params]
 
 def write_cell_file(cell, output_file, input_file=None):
     """

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -358,8 +358,6 @@ class StreamInterface:
                     
             if line.find("Cell parameters") != -1:
                 cell = line.split()[2:5] + line.split()[6:9]
-                if float(cell[2])*10.0 > 96 and write:
-                    print(stream_file, cell[2], n_chunk, n_crystal)
                 n_crystal += 1
                 
                 if (n_chunk, n_crystal+1) not in target:

--- a/btx/misc/xtal.py
+++ b/btx/misc/xtal.py
@@ -4,11 +4,9 @@ def cos_sq(angles):
     """ Compute cosine squared of input angles in radians. """
     return np.square(np.cos(angles))
 
-
 def sin_sq(angles):
     """ Compute sine squared of input angles in radianss. """
     return np.square(np.sin(angles))
-
 
 def compute_resolution(cell, hkl):
     """
@@ -18,7 +16,7 @@ def compute_resolution(cell, hkl):
     Parameters
     ----------
     cell : numpy.ndarray, shape (n_refl, 6)
-        unit cell parameters (a,b,c,alpha,beta,gamma)
+        unit cell parameters (a,b,c,alpha,beta,gamma) in Ang/deg
     hkl : numpy.ndarray, shape (n_refl, 3)
         Miller indices of reflections
             
@@ -28,8 +26,8 @@ def compute_resolution(cell, hkl):
         resolution associated with each reflection in 1/Angstrom
     """
 
-    a,b,c = [10.0 * cell[:,i] for i in range(3)] # nm to Angstrom
-    alpha,beta,gamma = [np.radians(cell[:,i]) for i in range(3,6)] # degrees to radians
+    a,b,c = [cell[:,i] for i in range(3)] 
+    alpha,beta,gamma = [np.radians(cell[:,i]) for i in range(3,6)] 
     h,k,l = [hkl[:,i] for i in range(3)]
 
     pf = 1.0 - cos_sq(alpha) - cos_sq(beta) - cos_sq(gamma) + 2.0*np.cos(alpha)*np.cos(beta)*np.cos(gamma)
@@ -40,7 +38,6 @@ def compute_resolution(cell, hkl):
 
     return np.sqrt((n1 + n2a + n2b + n2c) / pf)
 
-
 def compute_cell_volume(cell):
     """
     Compute unit cell volume.
@@ -48,15 +45,15 @@ def compute_cell_volume(cell):
     Parameters
     ----------
     cell : numpy.ndarray, shape (n_refl, 6)
-        unit cell parameters (a,b,c,alpha,beta,gamma)
+        unit cell parameters (a,b,c,alpha,beta,gamma) in Ang/deg
 
     Returns
     -------
     volume : numpy.ndarray, shape (n_refl)
         unit cell volume in Angstroms cubed
     """
-    a,b,c = [10.0 * cell[:,i] for i in range(3)] # nm to Angstrom
-    alpha,beta,gamma = [np.radians(cell[:,i]) for i in range(3,6)] # degrees to radians    
+    a,b,c = [10.0 * cell[:,i] for i in range(3)] 
+    alpha,beta,gamma = [np.radians(cell[:,i]) for i in range(3,6)] 
     
     volume = 1.0 - cos_sq(alpha) - cos_sq(beta) - cos_sq(gamma) + 2.0*np.cos(alpha)*np.cos(beta)*np.cos(gamma)
     volume = a*b*c*np.sqrt(volume)


### PR DESCRIPTION
The `StreamInterface` class has been altered to avoid running out of memory when `cell_only=False` so that we won't have to skip plotting the peakogram for large stream files. This was accomplished by changing the class's `self.stream_data` variable, which is now a dictionary rather than a 14 x n_reflections numpy array. The `StreamInterface` class stores the cell parameters in Angstroms / degrees, so a function in xtal.py (which previously expected the cell lengths in nanometers) has been updated as well.

The ccp4 path has also been updated in ischeduler.py