### PR TITLE
Reporting multi-lattice hits

### DIFF
--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -311,18 +311,22 @@ class StreamInterface:
         if output is not None:
             fig.savefig(output, dpi=300)
 
-    def report(self, update_url=None):
+    def report(self, tag=None):
         """
         Summarize the cell parameters and optionally report to the elog.
     
         Parameters
         ----------
-        update_url : str
-            elog URL for posting progress update
+        tag : str
+            suffix for naming summary file
         """
         # write summary file
+        if tag is not None:
+            tag = "_" + tag
+        else:
+            tag = ""
         counts = np.bincount(self.stream_data['n_lattice'])
-        summary_file = os.path.join(os.path.dirname(self.input_files[0]), "stream.summary")
+        summary_file = os.path.join(os.path.dirname(self.input_files[0]), f"stream{tag}.summary")
         with open(summary_file, 'w') as f:
             f.write("Cell mean: " + " ".join(f"{self.cell_params[i]:.3f}" for i in range(self.cell_params.shape[0])) + "\n")
             f.write("Cell std: " + " ".join(f"{self.cell_params_std[i]:.3f}" for i in range(self.cell_params.shape[0])) + "\n")

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -117,8 +117,8 @@ class Indexer:
             
         # write summary file
         with open(self.indexing_summary, 'w') as f:
-            f.write(f"Number of indexed events: {n_indexed}\n")
-            f.write(f"Fractional indexing rate rate: {(n_indexed/n_total):.2f}\n")
+            f.write(f"Number of lattices found: {n_indexed}\n")
+            f.write(f"Fractional indexing rate rate (including multiple lattices): {(n_indexed/n_total):.2f}\n")
 
         # post to elog
         update_url = os.environ.get('JID_UPDATE_COUNTERS')
@@ -133,8 +133,8 @@ class Indexer:
                 requests.post(update_url, json=[{ "key": f"{pf_keys[0]}", "value": f"{pf_vals[0]}"},
                                                 { "key": f"{pf_keys[1]}", "value": f"{pf_vals[1]}"},
                                                 { "key": f"{pf_keys[2]}", "value": f"{pf_vals[2]}"},
-                                                { "key": "Number of indexed events", "value": f"{n_indexed}"},
-                                                { "key": "Fractional indexing rate", "value": f"{(n_indexed/n_total):.2f}"}, ])
+                                                { "key": "Number of lattices found", "value": f"{n_indexed}"},
+                                                { "key": "Fractional indexing rate (including multiple lattices)", "value": f"{(n_indexed/n_total):.2f}"}, ])
             except:
                 print("Could not communicate with the elog update url")
 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -175,7 +175,7 @@ def stream_analysis(config):
     st = StreamInterface(input_files=glob.glob(stream_files), cell_only=task.get('cell_only') if task.get('cell_only') is not None else False)
     if st.rank == 0:
         logger.debug(f'Read stream files: {stream_files}')
-        st.report()
+        st.report(tag=task.tag)
         st.plot_cell_parameters(output=os.path.join(taskdir, f"figs/cell_{task.tag}.png"))
         if not st.cell_only:
             st.plot_peakogram(output=os.path.join(taskdir, f"figs/peakogram_{task.tag}.png"))


### PR DESCRIPTION
The `StreamInterface` class has been updated to track the distribution of multi-lattice hits and report related statistics. (Previously it only reported on the unit cell parameters.) A function to plot the distribution of unindexed/single hits/multi-lattice events has also been added, and the terminology of the summary file has been changed from stream.summary to stream_{task.tag}.summary. Unfortunately, we can't easily determine the number of single vs. multiple hits without reading the stream file in full -- no easy way to grep ourselves out of this pickle, so the statistics reported by the `Indexer` class now clarify that these values include multi-lattice events. 

This also resolves the question of why run 25 from mfxx49820 had >100% indexing rate. As the plot below from the full experiment shows, indexing uncovered numerous multi-lattice events.
![download-1](https://user-images.githubusercontent.com/6363287/202328450-3c14dd97-a8b7-4205-94b2-bc0a7ae8aea0.png)
