### PR TITLE
Routing `stream_analysis` task through ischeduler

### DIFF
--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -533,6 +533,10 @@ def cluster_cell_params(cell, out_clusters, out_cell, in_cell=None, eps=5, min_s
     results = np.array([np.concatenate((np.array([counts[nc], counts[nc]/np.sum(counts)]), 
                                         np.median(cell[clustering.labels_==nc], axis=0))) for nc in sort_idx])
     
+    if len(results) == 0:
+        print(f"No clusters found from {cell.shape[0]} crystals.")
+        return
+
     fmt=['%d', '%.2f', '%.2f', '%.2f', '%.2f', '%.2f', '%.2f', '%.2f']
     np.savetxt(out_clusters, results, header=' '.join(cols), fmt=fmt)
     

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -531,7 +531,8 @@ def visualize_hits(fname, exp, run, det_type, savepath=None, vmax_ind=3, vmax_po
     powder_hits = f['entry_1/data_1/powderHits'][:]
     powder_misses = f['entry_1/data_1/powderMisses'][:]
     shape = f['entry_1/data_1/data'].shape
-    indices = np.sort(np.random.randint(low=0, high=shape[0], size=9))
+    rng = np.random.default_rng()
+    indices = np.sort(rng.choice(shape[0], 9, replace=False))
     hits = f['entry_1/data_1/data'][indices]
     
     if det_type is not 'Rayonix':
@@ -543,22 +544,20 @@ def visualize_hits(fname, exp, run, det_type, savepath=None, vmax_ind=3, vmax_po
     
     # individual hits
     fig1, axs = plt.subplots(nrows=3, ncols=3, figsize=(6,6),dpi=180)
-    n_hits = hits.shape[0]
-    rand_sel = np.random.randint(0, high=n_hits, size=9)
     
     k=0
     for i in np.arange(3):
         for j in np.arange(3):
-            if k >= n_hits:
+            if k >= len(indices):
                 break
             axs[i,j].imshow(hits[k] * mask, vmin=0,vmax=vmax_ind*hits[k].mean(),cmap='Greys')
             axs[i,j].axis('off')
-            npeaks = f['entry_1/result_1/nPeaks'][rand_sel[k]]
+            npeaks = f['entry_1/result_1/nPeaks'][indices[k]]
             axs[i,j].set_title(f'# of peaks: {npeaks}')
             for ipeak in np.arange(npeaks):
-                panel_num = f['entry_1/result_1/peakYPosRaw'][rand_sel[k]] // psi.det.shape()[1]
-                panel_row = f['entry_1/result_1/peakYPosRaw'][rand_sel[k]] % psi.det.shape()[1]
-                panel_col = f['entry_1/result_1/peakXPosRaw'][rand_sel[k]]
+                panel_num = f['entry_1/result_1/peakYPosRaw'][indices[k]] // psi.det.shape()[1]
+                panel_row = f['entry_1/result_1/peakYPosRaw'][indices[k]] % psi.det.shape()[1]
+                panel_col = f['entry_1/result_1/peakXPosRaw'][indices[k]]
                 pixel = pixel_index_map[int(panel_num[ipeak]), int(panel_row[ipeak]), int(panel_col[ipeak])]
                 circle = plt.Circle((pixel[1],pixel[0]),20, color='blue', alpha=0.2)
                 axs[i,j].add_patch(circle)


### PR DESCRIPTION
The following changes were made:
1. The `stream_analysis` task was updated to use `JobScheduler`. If the requested number of cores exceeds the number of stream files, the number of cores is reduced to one core:stream file. An example yaml entry looks like this:
```
stream_analysis:
  tag: 'lyso_ngeo'
  cell_only: False
  ref_cell: '/cds/data/drpsrcf/mfx/mfxp22421/scratch/btx/cell/lyso.cell'
  ncores: 6
```
Note that neither the `ncores` nor `ref_cell` arguments are required. The latter should only be supplied if one wants to transfer the symmetry information from a different CrystFEL cell file to the one written out by this task.
2. Rather than exiting with an error when no clusters are found, `cluster_cell_params` returns a sensible warning message.
3. A correction was made to a visualizer function in the peak finding module to deal with an indexing error.