### PR TITLE
Anomalous data processing

### DIFF
--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -192,7 +192,7 @@ class Geoptimizer:
                                         ncores=params.get('ncores') if params.get('ncores') is not None else 16)
             stream_to_mtz.cmd_partialator(iterations=params.iterations, model=params.model, 
                                           min_res=params.get('min_res'), push_res=params.get('push_res'))
-            stream_to_mtz.cmd_compare_hkl(foms=params.foms.split(" "), nshells=1, highres=params.get('highres'))
+            stream_to_mtz.cmd_compare_hkl(foms=['CCstar','Rsplit'], nshells=1, highres=params.get('highres'))
             stream_to_mtz.cmd_get_hkl(highres=params.get('highres'))
             stream_to_mtz.js.write_main(f"echo {jobname} | tee -a {statusfile}\n")
             stream_to_mtz.launch()
@@ -201,7 +201,7 @@ class Geoptimizer:
             time.sleep(self.frequency)
             
         self.check_status(statusfile, jobnames)
-        self.extract_stats(params.foms.split(' '))
+        self.extract_stats(['CCstar','Rsplit'])
         
     def extract_stats(self, foms):
         """

--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -158,6 +158,8 @@ class Geoptimizer:
             time.sleep(self.frequency)
             
         self.check_status(statusfile, jobnames)
+        for fname in glob.glob(os.path.join(self.scan_dir, "r*", "stream*summary")):
+            shutil.move(fname, self.scan_dir)
             
     def launch_merging(self, params):
         """
@@ -213,8 +215,12 @@ class Geoptimizer:
         self.cols.append('n_indexed')
         n_indexed = np.zeros(self.scan_results.shape[0])
         for num in range(self.scan_results.shape[0]):
-            st = StreamInterface([os.path.join(self.scan_dir, f'g{num}.stream')], cell_only=True)
-            n_indexed[num] = st.n_indexed
+            fname = os.path.join(self.scan_dir, f"stream_g{num}.summary")
+            with open(fname, "r") as f:
+                lines = f.readlines()
+                for line in lines:
+                    if "Number of indexed events" in line:
+                        n_indexed[num] = int(line.split(":")[1])
         self.scan_results[:,4] = n_indexed
         
         statsdir = os.path.join(self.scan_dir, "merge", "hkl")

--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -193,7 +193,9 @@ class Geoptimizer:
             stream_to_mtz.cmd_partialator(iterations=params.iterations, model=params.model, 
                                           min_res=params.get('min_res'), push_res=params.get('push_res'))
             stream_to_mtz.cmd_compare_hkl(foms=['CCstar','Rsplit'], nshells=1, highres=params.get('highres'))
-            stream_to_mtz.cmd_get_hkl(highres=params.get('highres'))
+            stream_to_mtz.cmd_hkl_to_mtz(space_group=params.get('space_group') if params.get('space_group') is not None else 1,
+                                         highres=params.get('highres'), 
+                                         xds_style=False)
             stream_to_mtz.js.write_main(f"echo {jobname} | tee -a {statusfile}\n")
             stream_to_mtz.launch()
 

--- a/btx/interfaces/imtz.py
+++ b/btx/interfaces/imtz.py
@@ -3,8 +3,145 @@ import argparse
 import subprocess
 import os
 from btx.interfaces.ischeduler import *
+from btx.misc.xtal import enforce_symmetry
 
-def run_dimple(mtz, pdb, outdir, queue='ffbh3q', ncores=16):
+def write_create_xscale(out_hkl, cell, sg_number=1, exe="create-xscale"):
+    """
+    Write a create-xscale file for converting an hkl file from CrystFEL 
+    to XDS format. Original file can be found here:
+    https://github.com/biochem-fan/CrystFEL/blob/master/scripts/create-xscale
+    
+    Parameters
+    ----------
+    out_hkl : str
+        name of output hkl file
+    cell : ndarray, shape (6,)
+        unit cell parameters
+    sg_number : int
+        space group number
+    exe : str
+        name of executable file
+    """
+    cell = enforce_symmetry(cell, sg_number)
+    
+    with open(exe, "w") as f:
+        f.write("#!/usr/bin/perl -w\n\n")
+        f.write("use strict;\n\n")
+        f.write(f"open(FH, '{out_hkl}');\n\n")
+        f.write('printf("' + "!FORMAT=XDS_ASCII   MERGE=TRUE   FRIEDEL'S_LAW=TRUE" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!SPACE_GROUP_NUMBER={sg_number}" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!UNIT_CELL_CONSTANTS=      {cell[0]:.2f}    {cell[1]:.2f}   {cell[2]:.2f} {cell[3]:.3f} {cell[4]:.3f}    {cell[5]:.3f}" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!NUMBER_OF_ITEMS_IN_EACH_DATA_RECORD=5" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!X-RAY_WAVELENGTH= -1.0" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!ITEM_H=1" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!ITEM_K=2" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!ITEM_L=3" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!ITEM_IOBS=4" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!ITEM_SIGMA(IOBS)=5" + "\\n" + '");' + "\n")
+        f.write('printf("' + f"!END_OF_HEADER" + "\\n" + '");' + "\n\n")
+        
+        f.write("my $line;\n")
+        f.write("while ( $line = <FH> ) {\n")
+        f.write("\n\tchomp($line);\n\n")
+        f.write("\tif ( $line =~ /^\s+([0-9\-]+)\s+([0-9\-]+)\s+([0-9\-]+)\s+([0-9\.\-]+)\s+([\-]+)\s+([0-9\.\-]+)/ ) {\n\n")
+        f.write("\t\tmy $h = $1;\n")
+        f.write("\t\tmy $k = $2;\n")
+        f.write("\t\tmy $l = $3;\n")
+        f.write("\t\tmy $int = $4;\n")
+        f.write("\t\tmy $sig = $6;\n\n")
+        f.write('\t\tprintf("%6i %6i %5i %9.2f %9.2f\\n", $h, $k, $l, $int, $sig);\n\n')
+        f.write("\t} else {\n\n")
+        f.write('\t\tprintf(STDERR "Unrecognised:' + " '%s'" + "\\n" + '", $line' + ');' + "\n\n")
+        
+        f.write("\t}\n\n")
+        f.write("}\n\n")
+        
+        f.write('printf("!END_OF_DATA");\n')
+        f.write("close(FH);")
+
+def write_xds_inp(hklfile, res_range=None, anomalous=True, inp_path="."):
+    """
+    Write the input file required for xdsconv, which outputs
+    temp.hkl, F2MTZ.INP, and XDSCONV.LP files. These are the 
+    inputs for ccp4's f2mtz program.
+    
+    Parameters
+    ----------
+    hklfile : str
+        hkl file to convert
+    res_range : tuple
+        (low_res, high_res) cutoffs in Angstroms
+    anomalous : bool
+        if False, merge Friedel pairs
+    inp_path : str
+        working directory
+    """
+    with open(os.path.join(inp_path, "XDSCONV.INP"), "w") as f:
+        f.write(f"INPUT_FILE={hklfile}\n")
+        if res_range is not None:
+            f.write(f"INCLUDE_RESOLUTION_RANGE={res_range[0]} {res_range[1]}\n")
+        f.write("OUTPUT_FILE=temp.hkl  CCP4_I\n")
+        if anomalous:
+            f.write("FRIEDEL'S_LAW=FALSE\n")
+        else:
+            f.write("FRIEDEL'S_LAW=TRUE\n")
+
+def write_anomalous_f2mtz(cell, sg_number=1, fname="F2MTZ.INP"):
+    """
+    Write an F2MTZ.INP file specific for anomalous data.
+    
+    Parameters
+    ----------
+    cell : ndarray, shape (6,)
+        unit cell parameters
+    sg_number : int
+        space group number
+    fname : str
+        output file
+    """    
+    cell = enforce_symmetry(cell, sg_number)
+    
+    template = ("TITLE XDS to MTZ\n"
+                "FILE temp.hkl\n"
+                "SYMMETRY   {space_group}\n"
+                "CELL {cell}\n"
+                "LABOUT  H K L IMEAN SIGIMEAN I(+) SIGI(+) I(-) SIGI(-) ISYM\n"
+                "CTYPOUT H H H   J      Q      K     M      K      M      Y\n"
+                "END\n")
+    
+    context = {
+        "space_group": sg_number,
+        "cell": "    ".join([f"{c:.3f}" for c in cell])
+    }
+    
+    with open(fname, "w") as outfile:
+        outfile.write(template.format(**context))
+
+def f2mtz_command(outmtz):
+    """
+    Return command to convert from an XDS-formatted hkl
+    to an mtz file.
+    
+    Parameters
+    ----------
+    outmtz : str
+        name of output mtz file
+    
+    Returns
+    -------
+    command : str
+        commands to run ccp4's f2mtz and cad
+    """
+         
+    command = ("f2mtz HKLOUT temp.mtz<F2MTZ.INP\n"
+    f"cad HKLIN1 temp.mtz HKLOUT {outmtz}<<EOF\n"
+    "LABIN FILE 1 ALL\n"
+    "END\n"
+    "EOF\n")
+    
+    return command
+
+def run_dimple(mtz, pdb, outdir, queue='ffbh3q', ncores=16, anomalous=False):
     """
     Run dimple to solve the structure: 
     http://ccp4.github.io/dimple/.
@@ -17,9 +154,13 @@ def run_dimple(mtz, pdb, outdir, queue='ffbh3q', ncores=16):
         input PDB file for phasing or rigid body refinement
     outdir : str
         output directory for storing results
+    anomalous : bool
+        if True, generate an anomalous difference map
     """
     os.makedirs(outdir, exist_ok=True)
-    command = f"dimple {mtz} {pdb} {outdir}\n"
+    command = f"dimple {mtz} {pdb} {outdir}"
+    if anomalous:
+        command += " --anode"
 
     js = JobScheduler(os.path.join(outdir, "dimple.sh"),
                       logdir=outdir,
@@ -27,7 +168,7 @@ def run_dimple(mtz, pdb, outdir, queue='ffbh3q', ncores=16):
                       jobname=f'dimple', 
                       queue=queue)
     js.write_header()
-    js.write_main(command, dependencies=['ccp4'])
+    js.write_main(command + "\n", dependencies=['ccp4'])
     js.clean_up()
     js.submit()
 
@@ -43,6 +184,7 @@ def parse_input():
     parser.add_argument('--outdir', required=False, type=str, help='Directory for output')
     parser.add_argument('--ncores', required=False, type=int, default=16, help='Number of cores')
     parser.add_argument('--queue', required=False, type=str, default='ffbh3q', help='Queue to submit to')
+    parser.add_argument('--anomalous', required=False, type=bool, default=False, help='Anomalous data')
 
     return parser.parse_args()
 
@@ -50,4 +192,9 @@ if __name__ == '__main__':
 
     params = parse_input()
     if params.dimple:
-        run_dimple(params.mtz, params.pdb, params.outdir, queue=params.queue, ncores=params.ncores)
+        run_dimple(params.mtz, 
+                   params.pdb, 
+                   params.outdir, 
+                   queue=params.queue, 
+                   ncores=params.ncores, 
+                   anomalous=params.anomalous)

--- a/btx/misc/xtal.py
+++ b/btx/misc/xtal.py
@@ -59,3 +59,53 @@ def compute_cell_volume(cell):
     volume = a*b*c*np.sqrt(volume)
     return volume
 
+def enforce_symmetry(cell, sg_number):
+    """
+    Impose space group symmetry on the unit cell parameters.
+    
+    Parameters
+    ----------
+    cell : ndarary, shape (6,)
+        unit cell parameters in Angstrom / degrees
+    sg_number : int
+        space group number
+        
+    Returns
+    -------
+    cell : ndarary, shape (6,)
+        unit cell parameters with symmetry enforced    
+    """
+    # monoclonic: alpha=gamma=90
+    if (sg_number>=3) and (sg_number<=15):
+        cell[3], cell[5] = 90, 90
+    
+    # orthorhombic: all angles are 90 degrees
+    if (sg_number>=15) and (sg_number<=74):
+        cell[3:] = 90, 90, 90
+        
+    # tetragonal: all angles are 90 degrees, a=b!=c
+    if (sg_number>=75) and (sg_number<=142):
+        mean_ab = np.mean(cell[:2])
+        cell[:2] = mean_ab, mean_ab
+        cell[3:] = 90, 90, 90
+    
+    # trigonal: 
+    if (sg_number>=143) and (sg_number<=167):
+        mean_abc = np.mean(cell[:3])
+        cell[:3] = mean_abc, mean_abc, mean_abc
+        mean_angle = np.mean(cell[3:])
+        cell[3:] = mean_angle, mean_angle, mean_angle
+    
+    # hexagonal: a=b!=c
+    if (sg_number>=168) and (sg_number<=194):
+        mean_ab = np.mean(cell[:2])
+        cell[:2] = mean_ab, mean_ab
+        cell[3:] = 90, 90, 120
+    
+    # cubic: all angles are 90 degrees, a=b=c
+    if (sg_number>=195):
+        mean_abc = np.mean(cell[:3])
+        cell[:3] = mean_abc, mean_abc, mean_abc
+        cell[3:] = 90, 90, 90
+    
+    return cell

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -5,6 +5,8 @@ import os
 import sys
 import requests
 from btx.interfaces.ischeduler import *
+from btx.interfaces.istream import read_cell_file
+from btx.interfaces.imtz import *
 
 class StreamtoMtz:
     
@@ -15,7 +17,7 @@ class StreamtoMtz:
     input stream file.
     """
     
-    def __init__(self, input_stream, symmetry, taskdir, cell, ncores=16, queue='ffbh3q', tmp_exe=None, mtz_dir=None):
+    def __init__(self, input_stream, symmetry, taskdir, cell, ncores=16, queue='ffbh3q', tmp_exe=None, mtz_dir=None, anomalous=False):
         self.stream = input_stream # file of unmerged reflections, str
         self.symmetry = symmetry # point group symmetry, str
         self.taskdir = taskdir # path for storing output, str
@@ -23,6 +25,7 @@ class StreamtoMtz:
         self.ncores = ncores # int, number of cores for merging
         self.queue = queue # cluster to submit job to
         self.mtz_dir = mtz_dir # directory to which to transfer mtz
+        self.anomalous = anomalous # whether to separate Bijovet pairs
         self._set_up(tmp_exe)
         
     def _set_up(self, tmp_exe):
@@ -82,7 +85,7 @@ class StreamtoMtz:
                 command += f" --push-res={push_res}"
         if max_adu is not None:
             command += f" --max_adu={max_adu}"
-        self.js.write_main(f"{command}\n", dependencies=['crystfel'])
+        self.js.write_main(f"{command}\n", dependencies=['crystfel', 'xds', 'ccp4'])
             
     def cmd_compare_hkl(self, foms=['CCstar','Rsplit'], nshells=10, highres=None):
         """
@@ -119,26 +122,44 @@ class StreamtoMtz:
         command=f"python {self.script_path} -i {self.stream} --symmetry {self.symmetry} --cell {self.cell} --taskdir {self.taskdir} --foms {foms_args} --report --nshells={nshells} --mtz_dir {self.mtz_dir}"
         self.js.write_main(f"{command}\n")
                 
-    def cmd_get_hkl(self, highres=None, anomalous=False):
+    def cmd_hkl_to_mtz(self, space_group=1, highres=None, xds_style=False):
         """
         Convert hkl to mtz format using CrystFEL's get_hkl tool:
         https://www.desy.de/~twhite/crystfel/manual-get_hkl.html
+        if anomalous and xds_style are False. Otherwise, convert 
+        to mtz using a combination of xdsconv and f2mtz.
 
         Parameters
         ----------
+        space_group : int
+            space group number
         highres : float
             high-resolution cut-off in Angstroms
-        anomalous : bool
-            if True, separate Bijovet pairs
+        xds_style : bool
+            if True, use xdsconv/f2mtz regardless of anomalous status
         """
         outmtz = os.path.join(self.taskdir, f"{self.prefix}.mtz")
-        fmat = "mtz"
-        if anomalous:
-            fmat = "mtz-bij"
-        command = f"get_hkl -i {self.outhkl} -o {outmtz} -p {self.cell} --output-format={fmat}"
-        if highres is not None:
-            command += f" --highres={highres}"
-        self.js.write_main(f"{command}\n")
+        if self.anomalous or xds_style:
+            if space_group == 1:
+                print("Warning! Space group will be triclinic")
+            cell = read_cell_file(self.cell)
+            write_create_xscale(self.outhkl, cell, sg_number=space_group)
+            write_xds_inp("xdsformat.hkl",
+                          res_range=(100, highres) if highres is not None else None,
+                          anomalous=self.anomalous)
+            write_anomalous_f2mtz(cell, sg_number=space_group, fname="F2MTZ_ANO.INP")
+            self.js.write_main(f"chmod +x create-xscale\n")
+            self.js.write_main(f"./create-xscale > xdsformat.hkl\n")
+            self.js.write_main(f"xdsconv\n")
+            self.js.write_main(f"mv F2MTZ_ANO.INP F2MTZ.INP\n")
+            self.js.write_main(f2mtz_command(outmtz))
+            self.js.write_main("rm create-xscale XDSCONV.INP XDSCONV.LP F2MTZ.INP xdsformat.hkl temp.hkl temp.mtz \n")
+            
+        else:
+            command = f"get_hkl -i {self.outhkl} -o {outmtz} -p {self.cell} --output-format=mtz"
+            if highres is not None:
+                command += f" --highres={highres}"
+            self.js.write_main(f"{command}\n")        
 
     def launch(self):
         """
@@ -245,16 +266,18 @@ def parse_input():
     parser.add_argument('--symmetry', required=True, type=str, help='Point group symmetry')
     parser.add_argument('--taskdir', required=True, type=str, help='Base directory for storing merging output')
     parser.add_argument('--cell', required=True, type=str, help='File containing unit cell information (.pdb or .cell)')
+    parser.add_argument('--anomalous', required=False, type=bool, help='If True, separate Bijovet mates')
     # arguments specific to partialator
-    parser.add_argument('--model', default='unity', choices=['unity','xsphere'], type=str, help='Partiality model')
-    parser.add_argument('--iterations', default=1, type=int, help='Number of cycles of scaling and post-refinement to perform')
+    parser.add_argument('--model', required=False, default='unity', choices=['unity','xsphere'], type=str, help='Partiality model')
+    parser.add_argument('--iterations', required=False, default=1, type=int, help='Number of cycles of scaling and post-refinement to perform')
     parser.add_argument('--min_res', required=False, type=float, help='Minimum resolution for crystal to be merged')
     parser.add_argument('--push_res', required=False, type=float, help='Maximum resolution beyond min_res for reflection to be merged')
     parser.add_argument('--max_adu', required=False, type=float, help='Intensity cut-off for excluding saturated peaks')
-    # arguments for computing figures of merit
+    # arguments for computing figures of merit, converting to mtz
     parser.add_argument('--foms', required=False, default=['CCstar', 'Rsplit'], type=str, nargs='+', help='Figures of merit to calculate')
     parser.add_argument('--nshells', required=False, type=int, default=10, help='Number of resolution shells for computing figures of merit')
     parser.add_argument('--highres', required=False, type=float, help='High resolution limit for computing figures of merit') 
+    parser.add_argument('--space_group', required=False, type=int, default=1, help='Space group number, only required for anomalous data')
     # arguments for reporting
     parser.add_argument('--report', help='Report indexing results to summary file and elog', action='store_true')
     parser.add_argument('--update_url', help='URL for communicating with elog', required=False, type=str)
@@ -269,15 +292,28 @@ if __name__ == '__main__':
     
     params = parse_input()
     
-    stream_to_mtz = StreamtoMtz(params.input_stream, params.symmetry, params.taskdir, params.cell, 
-                                ncores=params.ncores, queue=params.queue, mtz_dir=params.mtz_dir)
+    stream_to_mtz = StreamtoMtz(params.input_stream, 
+                                params.symmetry, 
+                                params.taskdir, 
+                                params.cell, 
+                                ncores=params.ncores, 
+                                queue=params.queue, 
+                                mtz_dir=params.mtz_dir, 
+                                anomalous=params.anomalous)
     if not params.report:
-        stream_to_mtz.cmd_partialator(iterations=params.iterations, model=params.model, 
-                                      min_res=params.min_res, push_res=params.push_res, max_adu=params.max_adu)
+        stream_to_mtz.cmd_partialator(iterations=params.iterations, 
+                                      model=params.model, 
+                                      min_res=params.min_res, 
+                                      push_res=params.push_res, 
+                                      max_adu=params.max_adu)
         for ns in [1, params.nshells]:
-            stream_to_mtz.cmd_compare_hkl(foms=params.foms, nshells=ns, highres=params.highres)
-        stream_to_mtz.cmd_report(foms=params.foms, nshells=params.nshells)
-        stream_to_mtz.cmd_get_hkl(highres=params.highres)
+            stream_to_mtz.cmd_compare_hkl(foms=params.foms, 
+                                          nshells=ns, 
+                                          highres=params.highres)
+        stream_to_mtz.cmd_report(foms=params.foms, 
+                                 nshells=params.nshells)
+        stream_to_mtz.cmd_hkl_to_mtz(highres=params.highres, 
+                                     space_group=params.space_group)
         stream_to_mtz.launch()
     else:
         stream_to_mtz.report(foms=params.foms, nshells=params.nshells, update_url=params.update_url)

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -119,7 +119,7 @@ class StreamtoMtz:
         command=f"python {self.script_path} -i {self.stream} --symmetry {self.symmetry} --cell {self.cell} --taskdir {self.taskdir} --foms {foms_args} --report --nshells={nshells} --mtz_dir {self.mtz_dir}"
         self.js.write_main(f"{command}\n")
                 
-    def cmd_get_hkl(self, highres=None):
+    def cmd_get_hkl(self, highres=None, anomalous=False):
         """
         Convert hkl to mtz format using CrystFEL's get_hkl tool:
         https://www.desy.de/~twhite/crystfel/manual-get_hkl.html
@@ -128,9 +128,14 @@ class StreamtoMtz:
         ----------
         highres : float
             high-resolution cut-off in Angstroms
+        anomalous : bool
+            if True, separate Bijovet pairs
         """
         outmtz = os.path.join(self.taskdir, f"{self.prefix}.mtz")
-        command = f"get_hkl -i {self.outhkl} -o {outmtz} -p {self.cell} --output-format=mtz"
+        fmat = "mtz"
+        if anomalous:
+            fmat = "mtz-bij"
+        command = f"get_hkl -i {self.outhkl} -o {outmtz} -p {self.cell} --output-format={fmat}"
         if highres is not None:
             command += f" --highres={highres}"
         self.js.write_main(f"{command}\n")

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -225,13 +225,14 @@ def merge(config):
     foms = task.foms.split(" ")
     stream_to_mtz = StreamtoMtz(input_stream, task.symmetry, taskdir, cellfile, queue=setup.get('queue'), 
                                 ncores=task.get('ncores') if task.get('ncores') is not None else 16, 
-                                mtz_dir=os.path.join(setup.root_dir, "solve", f"{task.tag}"))
+                                mtz_dir=os.path.join(setup.root_dir, "solve", f"{task.tag}"),
+                                anomalous=task.get('anomalous') if task.get('anomalous') is not None else False)
     stream_to_mtz.cmd_partialator(iterations=task.iterations, model=task.model, 
                                   min_res=task.get('min_res'), push_res=task.get('push_res'), max_adu=task.get('max_adu'))
     for ns in [1, task.nshells]:
         stream_to_mtz.cmd_compare_hkl(foms=foms, nshells=ns, highres=task.get('highres'))
-    stream_to_mtz.cmd_get_hkl(highres=task.get('highres'),
-                              anomalous=task.get('anomalous') if task.get('anomalous') is not None else False)
+    stream_to_mtz.cmd_hkl_to_mtz(highres=task.get('highres'),
+                                 space_group=task.get('space_group') if task.get('space_group') is not None else 1)
     stream_to_mtz.cmd_report(foms=foms, nshells=task.nshells)
     stream_to_mtz.launch()
     logger.info(f'Merging launched!')

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -109,15 +109,21 @@ def opt_geom(config):
         task.n_peaks = [int(task.n_peaks)]
     else:
         task.n_peaks = [int(elem) for elem in task.n_peaks.split()]
+    if task.get('distance') is None:
+        task.distance = None
+    elif type(task.distance) == float or type(task.distance) == int:
+        task.distance = [float(task.distance)]
+    else:
+        task.distance = [float(elem) for elem in task.distance.split()]
     geom_opt = GeomOpt(exp=setup.exp,
                        run=setup.run,
                        det_type=setup.det_type)
     geom_opt.opt_geom(powder=os.path.join(setup.root_dir, f"powder/r{setup.run:04}_max.npy"),
                       mask=mask_file,
-                      distance=task.get('distance'),
+                      distance=task.distance,
                       center=centers,
                       n_iterations=task.get('n_iterations'), 
-                      n_peaks = task.n_peaks,
+                      n_peaks=task.n_peaks,
                       threshold=task.get('threshold'),
                       deltas=True,
                       plot=os.path.join(taskdir, f'figs/r{setup.run:04}.png'),

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -78,11 +78,16 @@ def run_analysis(config):
                         run=setup.run,
                         det_type=setup.det_type)
     logger.debug(f'Computing Powder for run {setup.run} of {setup.exp}...')
-    rd.compute_run_stats(max_events=task.max_events, mask=mask_file, threshold=task.get('mean_threshold'))
+    rd.compute_run_stats(max_events=task.max_events, 
+                         mask=mask_file, 
+                         threshold=task.get('mean_threshold'),
+                         gain_mode=task.get('gain_mode'))
     logger.info(f'Saving Powders and plots to {taskdir}')
     rd.save_powders(taskdir)
     rd.visualize_powder(output=os.path.join(taskdir, f"figs/powder_r{rd.psi.run:04}.png"))
     rd.visualize_stats(output=os.path.join(taskdir, f"figs/stats_r{rd.psi.run:04}.png"))
+    if task.get('gain_mode') is not None:
+        rd.visualize_gain_frequency(output=os.path.join(taskdir, f"figs/gain_freq_r{rd.psi.run:04}.png"))
     logger.debug('Done!')
     
 def opt_geom(config):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -230,7 +230,8 @@ def merge(config):
                                   min_res=task.get('min_res'), push_res=task.get('push_res'), max_adu=task.get('max_adu'))
     for ns in [1, task.nshells]:
         stream_to_mtz.cmd_compare_hkl(foms=foms, nshells=ns, highres=task.get('highres'))
-    stream_to_mtz.cmd_get_hkl(highres=task.get('highres'))
+    stream_to_mtz.cmd_get_hkl(highres=task.get('highres'),
+                              anomalous=task.get('anomalous') if task.get('anomalous') is not None else False)
     stream_to_mtz.cmd_report(foms=foms, nshells=task.nshells)
     stream_to_mtz.launch()
     logger.info(f'Merging launched!')
@@ -245,7 +246,8 @@ def solve(config):
                task.pdb, 
                taskdir,
                queue=setup.get('queue'),
-               ncores=task.get('ncores') if task.get('ncores') is not None else 16)
+               ncores=task.get('ncores') if task.get('ncores') is not None else 16,
+               anomalous=task.get('anomalous') if task.get('anomalous') is not None else False)
     logger.info(f'Dimple launched!')
 
 def refine_geometry(config, task=None):
@@ -278,7 +280,7 @@ def refine_geometry(config, task=None):
                         task.dy,
                         task.dz)
     geopt.launch_indexing(setup.exp, setup.det_type, config.index, cell_file)
-    geopt.launch_stream_analysis(config.index.cell)    
+    geopt.launch_stream_wrangling(config.stream_analysis)    
     geopt.launch_merging(config.merge)
     geopt.save_results(setup.root_dir, config.merge.tag)
     check_file_existence(os.path.join(task.scan_dir, "results.txt"), geopt.timeout)


### PR DESCRIPTION
The purpose of the bulk of these changes was to enable anomalous data processing, as requested in Issue #234. For that, entries that should be changed in the yaml compared to the non-anomalous case are shown below for a P43212 crystal :
```
merge:
...
  symmetry: '422_uac'
  foms: 'CCstar Rsplit ccano'
  anomalous: True
  space_group: 96

solve:
...
  anomalous: True
```
In the symmetry line, the inversion operator m should not be used as shown above. In the case of anomalous data, the hkl file output by partialator is handed off to XDS for conversion to ccp4 format, specifically using the create-xscale, xdsconv, f2mtz, and cad programs. Anomalous maps are generated using the program anode, which is called by dimple. (Note that the CrystFEL command `get_hkl` with setting `--output_format=mtz-bij` is insufficient because the output mtz only has the I(+) and I(-) columns and lacks the IMEAN column needed by ccp4 programs.)

Other changes include:
- `geoptimizer` uses the updated iScheduler-approach to calling `StreamInterface`
-  CC* and Rsplit are hardcoded as FOMs in `geoptimizer`, regardless of the anomalous flag in the yaml. (It seems unlikely that ccano will be relevant here.)
- The error in the `StreamInterface` elog reporter was fixed.
- A new function to enforce the space group symmetry on unit cell parameters was added. Note that currently we don't enforce space group symmetry when writing CrystFEL-style cell files, but perhaps we should.
- Updating the `opt_geom` task so that starting estimated distance(s) can be provided in the yaml.

The second round of changes update the `run_analysis` task to track gain mode statistics, though so far this is only implemented for the epix10k2M. In the case of autoranging medium/low gain, for instance, statistics regarding pixels pushed into the low gain mode can be gathered by modifying the yaml as follows:
```
run_analysis:
  max_events: -1
  gain_mode: 'AML-L'
```
A powder of the number of low gain counts per pixel will be saved to the powders folder, and plots like the following will be generated:
![ar_stats_r0030](https://user-images.githubusercontent.com/6363287/206385295-543fb3d4-5c3b-4912-9a08-be3f4a82580f.png)
![gain_freq_r0030](https://user-images.githubusercontent.com/6363287/206385307-f6c27f65-008e-41bc-978e-02019b20f3a8.png)

