### PR TITLE
Various updates to `RunDiagnostics`

### DIFF
--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -74,8 +74,7 @@ class RunDiagnostics:
             if self.psi.det_type != 'Rayonix':
                 for key in self.powders_final.keys():
                     self.powders_final[key] = assemble_image_stack_batch(self.powders_final[key], self.pixel_index_map)
-                    
-        self.panel_mask = assemble_image_stack_batch(np.ones(self.psi.det.shape()), self.pixel_index_map)
+                self.panel_mask = assemble_image_stack_batch(np.ones(self.psi.det.shape()), self.pixel_index_map)
  
     def save_powders(self, outdir, raw_img=False):
         """

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -358,40 +358,6 @@ class RunDiagnostics:
             exclude = True
         return exclude
 
-def launch_run_analysis(tmp_exe, queue, ncores, exp, run, det_type, outdir, mask=None, 
-                        max_events=None, mean_threshold=None, gain_mode=None, raw_img=False):
-    """
-    Launch run analysis task using iScheduler.
-    
-    Parameters
-    ----------
-    tmp_exe : str
-        name of temporary executable file
-    queue : str 
-        queue to submit job to
-    ncores : int
-        minimum of number of cores and number of stream files
-    For all other parameters, see parse_input definitions below.
-    """
-    script_path = os.path.abspath(__file__)
-    command = f"python {script_path} -e {exp} -r {run} -d {det_type} -o {outdir}"
-    if mask is not None:
-        command += f" -m {mask}"
-    if max_events is not None:
-        command += f" --max_events={max_events}"
-    if mean_threshold is not None:
-        command += f" --mean_threshold={mean_threshold}"
-    if gain_mode is not None:
-        command += f" --gain_mode={gain_mode}"
-    if raw_img:
-        command += f" --raw"
-        
-    js = JobScheduler(tmp_exe, ncores=ncores, jobname=f'ra_{run:04}', queue=queue)
-    js.write_header()
-    js.write_main(f"{command}\n", dependencies=['psana'])
-    #js.clean_up()
-    js.submit()
-    
 def main():
     """
     Perform run analysis, computing powders and tracking statistics.

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -7,6 +7,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.colors as colors
 from matplotlib.colors import LogNorm
 from btx.interfaces.ipsana import *
+from btx.interfaces.ischeduler import JobScheduler
 
 from psana import EventId
 from Detector.UtilsEpix10ka import find_gain_mode
@@ -41,12 +42,13 @@ class RunDiagnostics:
             unassembled, calibrated images of shape (n_panels, n_x, n_y)
         """
         if not self.powders:
-            for key in ['sum', 'sqr', 'max']:
+            for key in ['sum', 'sqr', 'max', 'min']:
                 self.powders[key] = img.copy()
         else:
             self.powders['sum'] += img
             self.powders['sqr'] += np.square(img)
             self.powders['max'] = np.maximum(self.powders['max'], img)
+            self.powders['min'] = np.minimum(self.powders['min'], img)
 
     def finalize_powders(self):
         """
@@ -55,6 +57,7 @@ class RunDiagnostics:
         """
         self.powders_final = dict()
         powder_max = np.array(self.comm.gather(self.powders['max'], root=0))
+        powder_min = np.array(self.comm.gather(self.powders['min'], root=0))
         powder_sum = np.array(self.comm.gather(self.powders['sum'], root=0))
         powder_sqr = np.array(self.comm.gather(self.powders['sqr'], root=0))
         total_n_proc = self.comm.reduce(self.n_proc, MPI.SUM)
@@ -63,6 +66,7 @@ class RunDiagnostics:
 
         if self.rank == 0:
             self.powders_final['max'] = np.max(powder_max, axis=0)
+            self.powders_final['min'] = np.min(powder_min, axis=0)
             self.powders_final['avg'] = np.sum(powder_sum, axis=0) / float(total_n_proc)
             self.powders_final['std'] = np.sqrt(np.sum(powder_sqr, axis=0) / float(total_n_proc) - np.square(self.powders_final['avg']))
             if self.gain_map is not None:
@@ -156,7 +160,7 @@ class RunDiagnostics:
         evt_map = map_pixel_gain_mode_for_raw(self.psi.det, raw)
         self.gain_map[evt_map==[self.modes[gain_mode]]] += 1
             
-    def compute_run_stats(self, max_events=-1, mask=None, powder_only=False, threshold=None, gain_mode=None):
+    def compute_run_stats(self, max_events=-1, mask=None, powder_only=False, threshold=None, gain_mode=None, raw_img=False):
         """
         Compute powders and per-image statistics. If a mask is provided, it is 
         only applied to the stats trajectories, not in computing the powder.
@@ -173,6 +177,8 @@ class RunDiagnostics:
             if supplied, exclude events whose mean is above this value
         gain_mode : str
             gain mode to retrieve statistics for, e.g. 'AML-L' 
+        raw_img : bool
+            if True, analyze raw rather than calibrated images
         """
         if mask is not None:
             if type(mask) == str:
@@ -192,7 +198,10 @@ class RunDiagnostics:
         for idx in np.arange(start_idx, end_idx):
             evt = self.psi.runner.event(self.psi.times[idx])
             self.psi.get_timestamp(evt.get(EventId))
-            img = self.psi.det.calib(evt=evt)
+            if raw_img:
+                img = self.psi.det.raw(evt=evt)
+            else:
+                img = self.psi.det.calib(evt=evt)
             if img is None:
                 n_empty += 1
                 continue
@@ -349,8 +358,60 @@ class RunDiagnostics:
             exclude = True
         return exclude
 
-#### For command line use ####
-            
+def launch_run_analysis(tmp_exe, queue, ncores, exp, run, det_type, outdir, mask=None, 
+                        max_events=None, mean_threshold=None, gain_mode=None, raw_img=False):
+    """
+    Launch run analysis task using iScheduler.
+    
+    Parameters
+    ----------
+    tmp_exe : str
+        name of temporary executable file
+    queue : str 
+        queue to submit job to
+    ncores : int
+        minimum of number of cores and number of stream files
+    For all other parameters, see parse_input definitions below.
+    """
+    script_path = os.path.abspath(__file__)
+    command = f"python {script_path} -e {exp} -r {run} -d {det_type} -o {outdir}"
+    if mask is not None:
+        command += f" -m {mask}"
+    if max_events is not None:
+        command += f" --max_events={max_events}"
+    if mean_threshold is not None:
+        command += f" --mean_threshold={mean_threshold}"
+    if gain_mode is not None:
+        command += f" --gain_mode={gain_mode}"
+    if raw_img:
+        command += f" --raw"
+        
+    js = JobScheduler(tmp_exe, ncores=ncores, jobname=f'ra_{run:04}', queue=queue)
+    js.write_header()
+    js.write_main(f"{command}\n", dependencies=['psana'])
+    #js.clean_up()
+    js.submit()
+    
+def main():
+    """
+    Perform run analysis, computing powders and tracking statistics.
+    """
+    params = parse_input()
+    os.makedirs(os.path.join(params.outdir, "figs"), exist_ok=True)
+    rd = RunDiagnostics(exp=params.exp,
+                        run=params.run,
+                        det_type=params.det_type)
+    rd.compute_run_stats(max_events=params.max_events, 
+                         mask=params.mask, 
+                         threshold=params.mean_threshold,
+                         gain_mode=params.gain_mode,
+                         raw_img=params.raw_img)
+    rd.save_powders(params.outdir)
+    rd.visualize_powder(output=os.path.join(params.outdir, f"figs/powder_r{params.run:04}.png"))
+    rd.visualize_stats(output=os.path.join(params.outdir, f"figs/stats_r{params.run:04}.png"))
+    if params.gain_mode is not None:
+        rd.visualize_gain_frequency(output=os.path.join(params.outdir, f"figs/gain_freq_r{params.run:04}.png"))
+
 def parse_input():
     """
     Parse command line input.
@@ -363,15 +424,10 @@ def parse_input():
     parser.add_argument('-m', '--mask', help='Binary mask for computing trajectories', required=False, type=str)
     parser.add_argument('--max_events', help='Number of images to process, -1 for full run', required=False, default=-1, type=int)
     parser.add_argument('--mean_threshold', help='Exclude images with a mean above this threshold', required=False, type=float)
+    parser.add_argument('--gain_mode', help='Gain mode to track, e.g. AML-L for epix10k2M autoranging low gain', required=False, type=str)
+    parser.add_argument('--raw_img', help="Analyze raw rather than calibrated images", action='store_true')
 
     return parser.parse_args()
 
 if __name__ == '__main__':
-    
-    params = parse_input()
-    rd = RunDiagnostics(exp=params.exp, run=params.run, det_type=params.det_type) 
-    rd.compute_run_stats(max_events=params.max_events, mask=params.mask, threshold=params.mean_threshold) 
-    rd.save_powders(params.outdir)
-    rd.visualize_powder(output=os.path.join(params.outdir, f"powder_r{rd.psi.run:04}.png"))
-    rd.visualize_stats(output=os.path.join(params.outdir, f"stats_r{rd.psi.run:04}.png"))
-
+    main()

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -77,7 +77,7 @@ class RunDiagnostics:
                     
         self.panel_mask = assemble_image_stack_batch(np.ones(self.psi.det.shape()), self.pixel_index_map)
  
-    def save_powders(self, outdir):
+    def save_powders(self, outdir, raw_img=False):
         """
         Save powders to output directory.
 
@@ -85,9 +85,14 @@ class RunDiagnostics:
         ----------
         output : str
             path to directory in which to save powders, optional
+        raw_img : bool
+            if True, save powder files with _raw nomenclature
         """
+        suffix=""
+        if raw_img:
+            suffix = "_raw"
         for key in self.powders_final.keys():
-            np.save(os.path.join(outdir, f"r{self.psi.run:04}_{key}.npy"), self.powders_final[key])
+            np.save(os.path.join(outdir, f"r{self.psi.run:04}_{key}{suffix}.npy"), self.powders_final[key])
 
     def compute_stats(self, img):
         """
@@ -372,11 +377,14 @@ def main():
                          threshold=params.mean_threshold,
                          gain_mode=params.gain_mode,
                          raw_img=params.raw_img)
-    rd.save_powders(params.outdir)
-    rd.visualize_powder(output=os.path.join(params.outdir, f"figs/powder_r{params.run:04}.png"))
-    rd.visualize_stats(output=os.path.join(params.outdir, f"figs/stats_r{params.run:04}.png"))
+    rd.save_powders(params.outdir, raw_img=params.raw_img)
+    suffix = ""
+    if params.raw_img:
+        suffix = "_raw"
+    rd.visualize_powder(output=os.path.join(params.outdir, f"figs/powder_r{params.run:04}{suffix}.png"))
+    rd.visualize_stats(output=os.path.join(params.outdir, f"figs/stats_r{params.run:04}{suffix}.png"))
     if params.gain_mode is not None:
-        rd.visualize_gain_frequency(output=os.path.join(params.outdir, f"figs/gain_freq_r{params.run:04}.png"))
+        rd.visualize_gain_frequency(output=os.path.join(params.outdir, f"figs/gain_freq_r{params.run:04}{suffix}.png"))
 
 def parse_input():
     """

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -18,7 +18,7 @@ class JobScheduler:
     def _find_python_path(self):
         """ Determine the relevant python path. """
         pythonpath=None
-        possible_paths = ["/cds/sw/ds/ana/conda1/inst/envs/ana-4.0.38-py3/bin/python"]
+        possible_paths = ["/cds/sw/ds/ana/conda1/inst/envs/ana-4.0.47-py3/bin/python"]
     
         try:
             pythonpath = os.environ['WHICHPYTHON']
@@ -56,6 +56,8 @@ class JobScheduler:
 
         with open(self.jobfile, 'w') as jfile:
             jfile.write(template.format(**context))
+            if 'SIT_PSDM_DATA' in os.environ:
+                jfile.write(f"\nexport SIT_PSDM_DATA={os.environ['SIT_PSDM_DATA']}\n")
 
     def _write_dependencies(self, dependencies):
         """ Source dependencies."""

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -97,7 +97,6 @@ CORES=${CORES:=1}
 # TODO: find_peaks needs to be handled from ischeduler. For now we do this...
 if [ ${TASK} != 'find_peaks' ] &&\
    [ ${TASK} != 'stream_analysis' ] &&\
-   [ ${TASK} != 'run_analysis' ] &&\
    [ ${TASK} != 'determine_cell' ] &&\
    [ ${TASK} != 'opt_geom' ]; then
   CORES=1

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -78,6 +78,9 @@ def run_analysis(config):
     command += f" -e {setup.exp} -r {setup.run} -d {setup.det_type} -o {taskdir} -m {mask_file}"
     if task.get('gain_mode') is not None:
         command += f" --gain_mode={task.gain_mode}"
+    if task.get('raw_img') is not None:
+        if task.raw_img:
+            command += f" --raw_img"
     js = JobScheduler(os.path.join(".", f'ra_{setup.run:04}.sh'), 
                       queue=setup.queue, 
                       ncores=task.ncores,

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -83,7 +83,8 @@ def run_analysis(config):
                       ncores=task.ncores,
                       jobname=f'ra_{setup.run:04}')
     js.write_header()
-    js.write_main(command, dependencies=['psana'])
+    js.write_main(f"{command}\n", dependencies=['psana'])
+    js.clean_up()
     js.submit()
     logger.debug('Run analysis launched!')
     

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -64,7 +64,7 @@ def build_mask(config):
     logger.debug('Done!')
 
 def run_analysis(config):
-    from btx.diagnostics.run import RunDiagnostics
+    from btx.interfaces.ischeduler import JobScheduler
     from btx.misc.shortcuts import fetch_latest
     setup = config.setup
     task = config.run_analysis
@@ -73,22 +73,19 @@ def run_analysis(config):
     os.makedirs(taskdir, exist_ok=True)
     os.makedirs(os.path.join(taskdir, 'figs'), exist_ok=True)
     mask_file = fetch_latest(fnames=os.path.join(setup.root_dir, 'mask', 'r*.npy'), run=setup.run)
-    logger.debug(f'Applying mask: {mask_file}...')
-    rd = RunDiagnostics(exp=setup.exp,
-                        run=setup.run,
-                        det_type=setup.det_type)
-    logger.debug(f'Computing Powder for run {setup.run} of {setup.exp}...')
-    rd.compute_run_stats(max_events=task.max_events, 
-                         mask=mask_file, 
-                         threshold=task.get('mean_threshold'),
-                         gain_mode=task.get('gain_mode'))
-    logger.info(f'Saving Powders and plots to {taskdir}')
-    rd.save_powders(taskdir)
-    rd.visualize_powder(output=os.path.join(taskdir, f"figs/powder_r{rd.psi.run:04}.png"))
-    rd.visualize_stats(output=os.path.join(taskdir, f"figs/stats_r{rd.psi.run:04}.png"))
+    script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),  "../btx/diagnostics/run.py")
+    command = f"python {script_path}"
+    command += f" -e {setup.exp} -r {setup.run} -d {setup.det_type} -o {taskdir} -m {mask_file}"
     if task.get('gain_mode') is not None:
-        rd.visualize_gain_frequency(output=os.path.join(taskdir, f"figs/gain_freq_r{rd.psi.run:04}.png"))
-    logger.debug('Done!')
+        command += f" --gain_mode={task.gain_mode}"
+    js = JobScheduler(os.path.join(".", f'ra_{setup.run:04}.sh'), 
+                      queue=setup.queue, 
+                      ncores=task.ncores,
+                      jobname=f'ra_{setup.run:04}')
+    js.write_header()
+    js.write_main(command, dependencies=['psana'])
+    js.submit()
+    logger.debug('Run analysis launched!')
     
 def opt_geom(config):
     from btx.diagnostics.geom_opt import GeomOpt


### PR DESCRIPTION
This PR includes the following changes:
1. The `run_analysis` task has been routed through the `JobScheduler` class. Only one core should be requested for the initial submission; the number of cores for the task should be specified in the yaml as `ncores`.
2. A minimum powder is generated and saved as well.
3. The default is to track statistics for calibrated images. However, raw images can be analyzed instead by including the entry `raw_img: True` in the yaml.
4. The `max_events` entry in the yaml for this task is no longer needed, since we assume that we always want to analyze the full run if running from the elog.
5. The python version in `JobScheduler` has been updated.
6. A fix was made for Issue #238. Thanks for catching that!

As an example, the following yaml entry would result in raw images being analyzed using 48 cores, with gain statistics for low gain mode tracked as well:
```
run_analysis:
  ncores: 48
  gain_mode: 'AML-L'
  raw_img: True
```