### PR TITLE
Bits mask for raw epix10k2M data

### DIFF
--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -204,6 +204,8 @@ class RunDiagnostics:
             self.psi.get_timestamp(evt.get(EventId))
             if raw_img:
                 img = self.psi.det.raw(evt=evt)
+                if self.psi.det_type == 'epix10k2M':
+                    img = img & 0x3fff # exclude first two bits for powder calculation
             else:
                 img = self.psi.det.calib(evt=evt)
             if img is None:
@@ -227,8 +229,6 @@ class RunDiagnostics:
                 if raw is None:
                     n_empty_raw +=1
                     continue
-                if self.psi.det_type == 'epix10k2M':
-                    raw = raw & 0x3fff # exclude first two bits
                 self.get_gain_statistics(raw, gain_mode)
             else:
                 self.gain_mode = ''
@@ -455,8 +455,10 @@ class PixelTracker:
                 
             else:
                 if self.psi.det_type == 'epix10k2M':
-                    raw = raw & 0x3fff # exclude first two bits
-                self.stats['raw'][n_processed] = raw[index[0], index[1], index[2]]
+                    raw_bmask = raw & 0x3fff # exclude first two bits
+                else:
+                    raw_bmask = raw
+                self.stats['raw'][n_processed] = raw_bmask[index[0], index[1], index[2]]
                 self.stats['calib'][n_processed] = calib[index[0], index[1], index[2]]
                 if gain_mode and self.psi.det_type == 'epix10k2M':
                     self.stats['gain'][n_processed] = map_pixel_gain_mode_for_raw(self.psi.det, raw)[index[0], index[1], index[2]]

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -227,6 +227,8 @@ class RunDiagnostics:
                 if raw is None:
                     n_empty_raw +=1
                     continue
+                if self.psi.det_type == 'epix10k2M':
+                    raw = raw & 0x3fff # exclude first two bits
                 self.get_gain_statistics(raw, gain_mode)
             else:
                 self.gain_mode = ''
@@ -452,6 +454,8 @@ class PixelTracker:
                 n_empty += 1
                 
             else:
+                if self.psi.det_type == 'epix10k2M':
+                    raw = raw & 0x3fff # exclude first two bits
                 self.stats['raw'][n_processed] = raw[index[0], index[1], index[2]]
                 self.stats['calib'][n_processed] = calib[index[0], index[1], index[2]]
                 if gain_mode and self.psi.det_type == 'epix10k2M':

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -268,7 +268,10 @@ class PsanaInterface:
                     if self.calibrate:
                         images[counter_batch] = self.det.calib(evt=evt)
                     else:
-                        images[counter_batch] = self.det.raw(evt=evt)
+                        raw = self.det.raw(evt=evt)
+                        if self.det_type == 'epix10k2M':
+                            raw = raw & 0x3fff # exclude first two bits
+                        images[counter_batch] = raw
                         
                 if self.track_timestamps:
                     self.get_timestamp(evt.get(EventId))


### PR DESCRIPTION
In raw data for the epix10k2M, a 14-bit mask should be applied since the first two bits do not correspond to the intensity value. See: https://github.com/lcls-psana/Detector/blob/master/src/UtilsEpix10ka.py#L43. 

Branch name reference: https://www.theguardian.com/world/2022/dec/16/jacinda-ardern-auctions-off-arrogant-prick-comment-to-raise-money-for-prostate-cancer-charity