### PR TITLE
Handling XPP rayonix and alternate PV

### DIFF
--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -162,7 +162,7 @@ class GeomOpt:
                                                self.distance,
                                                self.diagnostics.psi.get_pixel_size())[0] # in Angstrom
             
-    def deploy_geometry(self, outdir, pv_camera_length):
+    def deploy_geometry(self, outdir, pv_camera_length=None):
         """
         Write new geometry files (.geom and .data for CrystFEL and psana respectively) 
         with the optimized center and distance.

--- a/btx/diagnostics/geom_opt.py
+++ b/btx/diagnostics/geom_opt.py
@@ -73,11 +73,6 @@ class GeomOpt:
             output path for figure; if '', plot but don't save; if None, don't plot
         plot_final_only: bool
             if True, only generate plot for the best distance / center
-
-        Returns
-        -------
-        distance : float
-            estimated sample-detector distance in mm
         """
         
         if type(powder) == str:
@@ -167,19 +162,17 @@ class GeomOpt:
                                                self.distance,
                                                self.diagnostics.psi.get_pixel_size())[0] # in Angstrom
             
-    def deploy_geometry(self, outdir):
+    def deploy_geometry(self, outdir, pv_camera_length):
         """
         Write new geometry files (.geom and .data for CrystFEL and psana respectively) 
         with the optimized center and distance.
     
         Parameters
         ----------
-        center : tuple
-            optimized center (cx, cy) in pixels
-        distance : float
-            optimized sample-detector distance in mm
         outdir : str
             path to output directory
+        pv_camera_length : str
+            PV associated with camera length
         """
         # retrieve original geometry
         run = self.diagnostics.psi.run
@@ -199,14 +192,14 @@ class GeomOpt:
         psana_file, crystfel_file = os.path.join(outdir, f"r{run:04}_end.data"), os.path.join(outdir, f"r{run:04}.geom")
         temp_file = os.path.join(outdir, "temp.geom")
         geom.save_pars_in_file(psana_file)
-        generate_geom_file(self.diagnostics.psi.exp, run, self.diagnostics.psi.det_type, psana_file, temp_file)
+        generate_geom_file(self.diagnostics.psi.exp, run, self.diagnostics.psi.det_type, psana_file, temp_file, pv_camera_length)
         modify_crystfel_header(temp_file, crystfel_file)
         os.remove(temp_file)
 
         # Rayonix check
         if self.diagnostics.psi.get_pixel_size() != self.diagnostics.psi.det.pixel_size(run):
             print("Original geometry is wrong due to hardcoded Rayonix pixel size. Correcting geom file now...")
-            coffset = (self.distance - self.diagnostics.psi.get_camera_length()) / 1e3 # convert from mm to m
+            coffset = (self.distance - self.diagnostics.psi.get_camera_length(pv_camera_length)) / 1e3 # convert from mm to m
             res = 1e3 / self.diagnostics.psi.get_pixel_size() # convert from mm to um
             os.rename(crystfel_file, temp_file)
             modify_crystfel_coffset_res(temp_file, crystfel_file, coffset, res)

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -71,7 +71,7 @@ class RunDiagnostics:
             self.powders_final['std'] = np.sqrt(np.sum(powder_sqr, axis=0) / float(total_n_proc) - np.square(self.powders_final['avg']))
             if self.gain_map is not None:
                 self.powders_final['gain_mode_counts'] = np.sum(powder_gain, axis=0)
-            if self.psi.det_type != 'Rayonix':
+            if self.psi.det_type.lower() != 'rayonix':
                 for key in self.powders_final.keys():
                     self.powders_final[key] = assemble_image_stack_batch(self.powders_final[key], self.pixel_index_map)
                 self.panel_mask = assemble_image_stack_batch(np.ones(self.psi.det.shape()), self.pixel_index_map)

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -6,13 +6,12 @@ from PSCalib.GeometryAccess import GeometryAccess
 
 class PsanaInterface:
 
-    def __init__(self, exp, run, det_type, pv_camera_length=None,
+    def __init__(self, exp, run, det_type,
                  event_receiver=None, event_code=None, event_logic=True,
                  ffb_mode=False, track_timestamps=False, calibdir=None):
         self.exp = exp # experiment name, str
         self.run = run # run number, int
         self.det_type = det_type # detector name, str
-        self.pv = pv_camera_length # PV corresponding to camera length, str
         self.track_timestamps = track_timestamps # bool, keep event info
         self.seconds, self.nanoseconds, self.fiducials = [], [], []
         self.event_receiver = event_receiver # 'evr0' or 'evr1', str
@@ -127,28 +126,33 @@ class PsanaInterface:
         """
         return -1*np.mean(self.det.coords_z(self.run))/1e3
 
-    def get_camera_length(self):
+    def get_camera_length(self, pv_camera_length=None):
         """
         Retrieve the camera length (clen) in mm.
+
+        Parameters
+        ----------
+        pv_camera_length : str
+            PV associated with camera length
 
         Returns
         -------
         clen : float
-            clen, where clen = distance - coffset
+            clen, where clen = distance - coffset in mm
         """
-        if self.pv is None:
+        if pv_camera_length is None:
             if self.det_type == 'jungfrau4M':
-                self.pv = 'CXI:DS1:MMS:06.RBV'
+                pv_camera_length = 'CXI:DS1:MMS:06.RBV'
             if self.det_type == 'Rayonix':
-                self.pv = 'MFX:DET:MMS:04.RBV'
+                pv_camera_length = 'MFX:DET:MMS:04.RBV'
             if self.det_type == 'epix10k2M':
-                self.pv = 'MFX:ROB:CONT:POS:Z'
-            print(f"PV used to retrieve clen parameter: {self.pv}")
+                pv_camera_length = 'MFX:ROB:CONT:POS:Z'
+            print(f"PV used to retrieve clen parameter: {pv_camera_length}")
 
         try:
-            return self.ds.env().epicsStore().value(self.pv)
+            return self.ds.env().epicsStore().value(pv_camera_length)
         except TypeError:
-            raise RuntimeError(f"PV {self.pv} is invalid")
+            raise RuntimeError(f"PV {pv_camera_length} is invalid")
 
     def get_timestamp(self, evtId):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -6,12 +6,13 @@ from PSCalib.GeometryAccess import GeometryAccess
 
 class PsanaInterface:
 
-    def __init__(self, exp, run, det_type,
+    def __init__(self, exp, run, det_type, pv_camera_length=None,
                  event_receiver=None, event_code=None, event_logic=True,
                  ffb_mode=False, track_timestamps=False, calibdir=None):
         self.exp = exp # experiment name, str
         self.run = run # run number, int
         self.det_type = det_type # detector name, str
+        self.pv = pv_camera_length # PV corresponding to camera length, str
         self.track_timestamps = track_timestamps # bool, keep event info
         self.seconds, self.nanoseconds, self.fiducials = [], [], []
         self.event_receiver = event_receiver # 'evr0' or 'evr1', str
@@ -126,33 +127,28 @@ class PsanaInterface:
         """
         return -1*np.mean(self.det.coords_z(self.run))/1e3
 
-    def get_camera_length(self, pv=None):
+    def get_camera_length(self):
         """
         Retrieve the camera length (clen) in mm.
-
-        Parameters
-        ----------
-        pv : str
-            pv code for distance, optional
 
         Returns
         -------
         clen : float
             clen, where clen = distance - coffset
         """
-        if pv is None:
+        if self.pv is None:
             if self.det_type == 'jungfrau4M':
-                pv = 'CXI:DS1:MMS:06.RBV'
+                self.pv = 'CXI:DS1:MMS:06.RBV'
             if self.det_type == 'Rayonix':
-                pv = 'MFX:DET:MMS:04.RBV'
+                self.pv = 'MFX:DET:MMS:04.RBV'
             if self.det_type == 'epix10k2M':
-                pv = 'MFX:ROB:CONT:POS:Z'
-            print(f"PV used to retrieve clen parameter: {pv}")
+                self.pv = 'MFX:ROB:CONT:POS:Z'
+            print(f"PV used to retrieve clen parameter: {self.pv}")
 
         try:
-            return self.ds.env().epicsStore().value(pv)
+            return self.ds.env().epicsStore().value(self.pv)
         except TypeError:
-            raise RuntimeError(f"Invalid PV")
+            raise RuntimeError(f"PV {self.pv} is invalid")
 
     def get_timestamp(self, evtId):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -149,7 +149,10 @@ class PsanaInterface:
                 pv = 'MFX:ROB:CONT:POS:Z'
             print(f"PV used to retrieve clen parameter: {pv}")
 
-        return self.ds.env().epicsStore().value(pv)
+        try:
+            return self.ds.env().epicsStore().value(pv)
+        except TypeError:
+            raise RuntimeError(f"Invalid PV")
 
     def get_timestamp(self, evtId):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -74,7 +74,7 @@ class PsanaInterface:
         pixel_size : float
             detector pixel size in mm
         """
-        if self.det_type == 'Rayonix':
+        if self.det_type.lower() == 'rayonix':
             env = self.ds.env()
             cfg = env.configStore()
             pixel_size_um = cfg.get(psana.Rayonix.ConfigV2).pixelWidth()

--- a/btx/misc/metrology.py
+++ b/btx/misc/metrology.py
@@ -144,7 +144,7 @@ def offset_geom(input_file, output_file, dx, dy, dz):
             
     outfile.close()
     
-def generate_geom_file(exp, run, det_type, input_file, output_file, det_dist=None):
+def generate_geom_file(exp, run, det_type, input_file, output_file, det_dist=None, pv_camera_length=None):
     """
     Generate a Crystfel .geom file from either a psana .data or another
     Crystfel .geom file and set the coffset field for each panel based 
@@ -167,6 +167,8 @@ def generate_geom_file(exp, run, det_type, input_file, output_file, det_dist=Non
         output .geom file
     det_dist : float
         estimated sample-detector distance in mm
+    pv_camera_length : str
+        PV associated with the camera length
     """
     if 'CsPad' in det_type:
         sys.exit("Currently this function does not support the CsPad detector")
@@ -182,7 +184,7 @@ def generate_geom_file(exp, run, det_type, input_file, output_file, det_dist=Non
     psi = PsanaInterface(exp=exp, run=run, det_type=det_type)
     if det_dist is None:
         det_dist = psi.estimate_distance()
-    coffset = (det_dist - psi.get_camera_length()) / 1000.
+    coffset = (det_dist - psi.get_camera_length(pv_camera_length)) / 1000.
     
     geom.to_crystfel_file(output_file, coffset=coffset)
     

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -137,7 +137,7 @@ def opt_geom(config):
         logger.info(f'Refined detector distance in mm: {geom_opt.distance}')
         logger.info(f'Refined detector center in pixels: {geom_opt.center}')
         logger.info(f'Detector edge resolution in Angstroms: {geom_opt.edge_resolution}')    
-        geom_opt.deploy_geometry(taskdir)
+        geom_opt.deploy_geometry(taskdir, pv_camera_length=setup.get('pv_camera_length'))
         logger.info(f'Updated geometry files saved to: {taskdir}')
         logger.debug('Done!')
 
@@ -155,7 +155,7 @@ def find_peaks(config):
                     tag=task.tag, mask=mask_file, psana_mask=task.psana_mask, min_peaks=task.min_peaks, max_peaks=task.max_peaks,
                     npix_min=task.npix_min, npix_max=task.npix_max, amax_thr=task.amax_thr, atot_thr=task.atot_thr, 
                     son_min=task.son_min, peak_rank=task.peak_rank, r0=task.r0, dr=task.dr, nsigm=task.nsigm,
-                    calibdir=task.get('calibdir'))
+                    calibdir=task.get('calibdir'), pv_camera_length=setup.get('pv_camera_length'))
     logger.debug(f'Performing peak finding for run {setup.run} of {setup.exp}...')
     pf.find_peaks()
     pf.curate_cxi()


### PR DESCRIPTION
Two sets of changes:
1. Previously the `get_camera_function` in the `PsanaInterface` class accepted a non-default PV; the current revisions make this argument accessible from the `PeakFinder` and `GeomOpt` classes that rely on this function. In the yaml, the nonobligatory argument is `pv_camera_length` in the `setup` section. See Issue #253.
2. The checks for Rayonix detectors were made case-insensitive. (For xpplq9215, the detector name is all lower case.)

(Reference: https://www.theguardian.com/us-news/2022/dec/20/p-22-mountain-lion-los-angeles-death-reaction)