### PR TITLE
Handling mosflm dependency

### DIFF
--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -66,6 +66,7 @@ class JobScheduler:
             dep_paths += "source /reg/g/psdm/etc/psconda.sh -py3\n"
         if "crystfel" in dependencies:
             dep_paths += "export PATH=/cds/sw/package/crystfel/crystfel-dev/bin:$PATH\n"
+            dep_paths += "export PATH=/cds/sw/package/autosfx:$PATH\n"
         if "ccp4" in dependencies:
             dep_paths += "source /cds/sw/package/ccp4/ccp4-8.0/bin/ccp4.setup-sh\n"
         if "phenix" in dependencies:

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -66,6 +66,7 @@ class JobScheduler:
             dep_paths += "source /reg/g/psdm/etc/psconda.sh -py3\n"
         if "crystfel" in dependencies:
             dep_paths += "export PATH=/cds/sw/package/crystfel/crystfel-dev/bin:$PATH\n"
+        if "mosflm" in dependencies:
             dep_paths += "export PATH=/cds/sw/package/autosfx:$PATH\n"
         if "ccp4" in dependencies:
             dep_paths += "source /cds/sw/package/ccp4/ccp4-8.0/bin/ccp4.setup-sh\n"

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -87,7 +87,7 @@ class Indexer:
 
         js = JobScheduler(self.tmp_exe, ncores=self.ncores, jobname=f'idx_r{self.run:04}', queue=self.queue, time=self.time)
         js.write_header()
-        js.write_main(command, dependencies=['crystfel', 'xds', 'xgandalf'])
+        js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         js.clean_up()
         js.submit()
         print(f"Indexing executable written to {self.tmp_exe}")


### PR DESCRIPTION
The latest crystfel-dev installation in /cds/sw/package doesn't appear to come with mosflm. Mosflm has been installed separately (thanks @fredericpoitevin! And sorry about the double review request; I accidentally tried to merge into the wrong for first...), and its path is exported as a dependency if chosen as an indexing method.

(Reference: https://www.npr.org/2023/02/09/1155633439/wildlife-photographer-of-the-year)