### PR TITLE
Added ability to retrieve the beam attenuation for a given run.

### DIFF
--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -190,30 +190,31 @@ class PsanaInterface:
         except TypeError:
             raise RuntimeError(f"PV {pv_camera_length} is invalid")
 
-    def get_beam_attenuation(self, pv_beam_attenuation=None):
+    def get_beam_transmission(self, pv_beam_transmission=None):
         """
-        Attenuation set by beamline scientists before the beam reaches the sample.
+        Fraction of beam transmitted to the sample.
+        The attenuation is set by beamline scientists before the beam reaches the sample.
 
         Parameters
         ----------
-        pv_beam_attenuation : str
+        pv_beam_transmission : str
             PV associated with beam attenuation
 
         Returns
         -------
-        beam_attenuation : float
+        beam_transmission : float
             0.0 is no beam, 1.0 is full beam.
         """
-        if pv_beam_attenuation is None:
+        if pv_beam_transmission is None:
             if self.hutch == 'mfx':
-                pv_beam_attenuation = "MFX:ATT:COM:R_CUR"
+                pv_beam_transmission = "MFX:ATT:COM:R_CUR"
             else:
                 raise NotImplementedError
 
         try:
-            self.ds.env().epicsStore().value(pv_beam_attenuation)
+            self.ds.env().epicsStore().value(pv_beam_transmission)
         except TypeError:
-            raise RuntimeError(f"PV {pv_beam_attenuation} is invalid")
+            raise RuntimeError(f"PV {pv_beam_transmission} is invalid")
 
     def get_timestamp(self, evtId):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -128,7 +128,7 @@ class PsanaInterface:
         photon_energy : float
             photon energy in eV
         """
-        return psana.Detector('Ebeam').get(evt).ebeamPhotonEnergy()
+        return psana.Detector('EBeam').get(evt).ebeamPhotonEnergy()
 
     def get_fee_gas_detector_energy_mJ_evt(self, evt, mode=None):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -10,6 +10,7 @@ class PsanaInterface:
                  event_receiver=None, event_code=None, event_logic=True,
                  ffb_mode=False, track_timestamps=False, calibdir=None):
         self.exp = exp # experiment name, str
+        self.hutch = exp[:3] # hutch name, str
         self.run = run # run number, int
         self.det_type = det_type # detector name, str
         self.track_timestamps = track_timestamps # bool, keep event info
@@ -188,6 +189,31 @@ class PsanaInterface:
             return self.ds.env().epicsStore().value(pv_camera_length)
         except TypeError:
             raise RuntimeError(f"PV {pv_camera_length} is invalid")
+
+    def get_beam_attenuation(self, pv_beam_attenuation=None):
+        """
+        Attenuation set by beamline scientists before the beam reaches the sample.
+
+        Parameters
+        ----------
+        pv_beam_attenuation : str
+            PV associated with beam attenuation
+
+        Returns
+        -------
+        beam_attenuation : float
+            0.0 is no beam, 1.0 is full beam.
+        """
+        if pv_beam_attenuation is None:
+            if self.hutch == 'mfx':
+                pv_beam_attenuation = "MFX:ATT:COM:R_CUR"
+            else:
+                raise NotImplementedError
+
+        try:
+            self.ds.env().epicsStore().value(pv_beam_attenuation)
+        except TypeError:
+            raise RuntimeError(f"PV {pv_beam_attenuation} is invalid")
 
     def get_timestamp(self, evtId):
         """

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -226,7 +226,7 @@ class PsanaInterface:
                 raise NotImplementedError
 
         try:
-            self.ds.env().epicsStore().value(pv_beam_transmission)
+            return self.ds.env().epicsStore().value(pv_beam_transmission)
         except TypeError:
             raise RuntimeError(f"PV {pv_beam_transmission} is invalid")
 

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -96,7 +96,7 @@ class PsanaInterface:
     
     def get_wavelength_evt(self, evt):
         """
-        Retrieve the detector's wavelength for a specfic event.
+        Retrieve the detector's wavelength for a specific event.
 
         Parameters
         ----------
@@ -108,13 +108,27 @@ class PsanaInterface:
         wavelength : float
             wavelength in Angstrom
         """
-        ebeam = psana.Detector('EBeam')
-        photon_energy = ebeam.get(evt).ebeamPhotonEnergy()
+        photon_energy = self.get_photon_energy_eV_evt(evt)
         if np.isinf(photon_energy):
             return self.get_wavelength()
         else:
             lambda_m =  1.23984197386209e-06 / photon_energy # convert to meters using e=hc/lambda
             return lambda_m * 1e10
+
+    def get_photon_energy_eV_evt(self, evt):
+        """
+        Retrieve the photon energy in eV for a specific event.
+        Parameters
+        ----------
+        evt : psana.Event object
+            individual psana event
+
+        Returns
+        -------
+        photon_energy : float
+            photon energy in eV
+        """
+        return psana.Detector('Ebeam').get(evt).ebeamPhotonEnergy()
 
     def get_fee_gas_detector_energy_mJ_evt(self, evt, mode=None):
         """


### PR DESCRIPTION
Not tested yet but the idea is just:
```python
exp='mfxp23120'
run=19
psi = PsanaInterface(exp, run, 'epix10k2M')
pv_att = "MFX:ATT:COM:R_CUR"
psi.ds.env().epicsStore().value(pv_att)
```
which returns `0.10940339989647549` or 11% transmission.