### PR TITLE
`PsanaInterface` fixes for opal_tt detector and empty images

### DIFF
--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -322,13 +322,17 @@ class PsanaInterface:
             images retrieved sequentially from run, optionally assembled
         """
         # set up storage array
-        if assemble:
-            images = np.zeros((num_images, 
-                               self.det.image_xaxis(self.run).shape[0], 
-                               self.det.image_yaxis(self.run).shape[0]))
+        if self.det_type != 'opal_tt':
+            if assemble:
+                images = np.zeros((num_images, 
+                                   self.det.image_xaxis(self.run).shape[0], 
+                                   self.det.image_yaxis(self.run).shape[0]))
+            else:
+                images = np.zeros((num_images,) + self.det.shape())
         else:
-            images = np.zeros((num_images,) + self.det.shape())
-            
+            images = np.zeros((num_images, 230, 1024))
+            assemble = False
+
         # retrieve next batch of images
         for counter_batch in range(num_images):
             if self.counter >= self.max_events:

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -334,7 +334,8 @@ class PsanaInterface:
             assemble = False
 
         # retrieve next batch of images
-        for counter_batch in range(num_images):
+        counter_batch = 0
+        while counter_batch < num_images:
             if self.counter >= self.max_events:
                 images = images[:counter_batch]
                 print("No more events to retrieve")
@@ -342,19 +343,21 @@ class PsanaInterface:
                 
             else:
                 evt = self.runner.event(self.times[self.counter])
-                if assemble:
+                if assemble and self.det_type.lower()!='rayonix':
                     if not self.calibrate:
                         raise IOError("Error: calibration data not found for this run.")
                     else:
-                        images[counter_batch] = self.det.image(evt=evt)
+                        img = self.det.image(evt=evt)
                 else:
                     if self.calibrate:
-                        images[counter_batch] = self.det.calib(evt=evt)
+                        img = self.det.calib(evt=evt)
                     else:
-                        raw = self.det.raw(evt=evt)
+                        img = self.det.raw(evt=evt)
                         if self.det_type == 'epix10k2M':
-                            raw = raw & 0x3fff # exclude first two bits
-                        images[counter_batch] = raw
+                            img = img & 0x3fff # exclude first two bits
+                if img is not None:
+                    images[counter_batch] = img
+                    counter_batch += 1
                         
                 if self.track_timestamps:
                     self.get_timestamp(evt.get(EventId))


### PR DESCRIPTION
Unfortunately, it looks like the opal_tt detector is just plain weird: it lacks an `image_xaxis` class variable and calibration data, and the `shape()` method returns the wrong (possibly pre-cropped?) dimensions. So now it's handled as a special case in the `get_images` function. This should resolve the bug reported in issue #265.

The `get_images` function was also modified so that any images of NoneType are skipped as well.