### PR TITLE
`StreamInterface` updates and `refine_geometry` fix

### DIFF
--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -68,7 +68,7 @@ class StreamInterface:
                     for narr in range(1, len(stream_data[key])):
                         stream_data[key][narr] += stream_data[key][narr-1][-1]+1
                 stream_data[key] = np.concatenate(np.array(stream_data[key], dtype=object))
-                if key in ['n_crystal','n_chunk', 'n_crystal_cell', 'n_lattice', 'h', 'k', 'l']:
+                if key in ['n_crystal','n_chunk', 'n_crystal_cell', 'n_lattice', 'image_num', 'h', 'k', 'l']:
                     stream_data[key] = stream_data[key].astype(int)
                 else:
                     stream_data[key] = stream_data[key].astype(float)
@@ -126,7 +126,8 @@ class StreamInterface:
         """
         # set up storage arrays
         single_stream_data = {}
-        keys = ['a','b','c','alpha','beta','gamma','n_crystal','n_chunk', 'n_crystal_cell', 'n_lattice']
+        keys = ['a','b','c','alpha','beta','gamma','n_crystal','n_chunk', 
+                'n_crystal_cell','n_lattice','image_num','highres_A']
         if not self.cell_only:
             keys.extend(['h','k','l','sumI','sigI','maxI'])
         for key in keys:
@@ -146,6 +147,9 @@ class StreamInterface:
                     if in_refl:
                         in_refl = False
                         print(f"Warning! Line {lc} associated with chunk {n_chunk} is problematic: {line}")
+                        
+                if line.find("Image serial number") != -1:
+                    single_stream_data['image_num'].append(int(line.split()[-1]))
 
                 if line.find("Cell parameters") != -1:
                     cell = line.split()[2:5] + line.split()[6:9]
@@ -158,7 +162,10 @@ class StreamInterface:
                     if self.cell_only:
                         single_stream_data['n_crystal'].append(self.n_crystal)
                     n_lattice += 1
-
+                    
+                if line.find("diffraction_resolution_limit") != -1:
+                    single_stream_data['highres_A'].append(float(line.split()[-2]))
+                    
                 if line.find("End chunk") != -1:
                     single_stream_data['n_lattice'].append(n_lattice)
 

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -127,7 +127,8 @@ class StreamInterface:
         # set up storage arrays
         single_stream_data = {}
         keys = ['a','b','c','alpha','beta','gamma','n_crystal','n_chunk', 
-                'n_crystal_cell','n_lattice','image_num','highres_A']
+                'n_crystal_cell','n_lattice','image_num','highres_A',
+                'residual','det_shift_x','det_shift_y']
         if not self.cell_only:
             keys.extend(['h','k','l','sumI','sigI','maxI'])
         for key in keys:
@@ -165,6 +166,13 @@ class StreamInterface:
                     
                 if line.find("diffraction_resolution_limit") != -1:
                     single_stream_data['highres_A'].append(float(line.split()[-2]))
+
+                if line.find("final_residual") != -1:
+                    single_stream_data['residual'].append(float(line.split()[-1]))
+                    
+                if line.find("det_shift") != -1:
+                    single_stream_data['det_shift_x'].append(float(line.split()[3]))
+                    single_stream_data['det_shift_y'].append(float(line.split()[-2]))
                     
                 if line.find("End chunk") != -1:
                     single_stream_data['n_lattice'].append(n_lattice)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -280,9 +280,6 @@ def refine_geometry(config, task=None):
         task.dy = np.linspace(task.dy[0], task.dy[1], int(task.dy[2]))
         task.dz = tuple([float(elem) for elem in task.dz.split()])
         task.dz = np.linspace(task.dz[0], task.dz[1], int(task.dz[2]))
-        print("task.dx: ", task.dx)
-        print("task.dy: ", task.dy)
-        print("task.dz: ", task.dz)
     """ Refine detector center and/or distance based on the geometry that minimizes Rsplit. """
     taskdir = os.path.join(setup.root_dir, 'index')
     os.makedirs(task.scan_dir, exist_ok=True)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -274,9 +274,15 @@ def refine_geometry(config, task=None):
     if task is None:
         task = config.refine_geometry
         task.scan_dir = os.path.join(setup.root_dir, f'scan_{config.merge.tag}')
-        for var in [task.dx, task.dy, task.dz]:
-            var = tuple([float(elem) for elem in var.split()])
-            var = np.linspace(var[0], var[1], int(var[2]))
+        task.dx = tuple([float(elem) for elem in task.dx.split()])
+        task.dx = np.linspace(task.dx[0], task.dx[1], int(task.dx[2]))
+        task.dy = tuple([float(elem) for elem in task.dy.split()])
+        task.dy = np.linspace(task.dy[0], task.dy[1], int(task.dy[2]))
+        task.dz = tuple([float(elem) for elem in task.dz.split()])
+        task.dz = np.linspace(task.dz[0], task.dz[1], int(task.dz[2]))
+        print("task.dx: ", task.dx)
+        print("task.dy: ", task.dy)
+        print("task.dz: ", task.dz)
     """ Refine detector center and/or distance based on the geometry that minimizes Rsplit. """
     taskdir = os.path.join(setup.root_dir, 'index')
     os.makedirs(task.scan_dir, exist_ok=True)


### PR DESCRIPTION
The changes in this PR encompass:
1. an expansion of the stats tracked by the `StreamInterface` class to include detector shifts, peak observed vs predicted residuals, maximum resolution peak per indexed crystal, and image serial number. The last is needed to map the data stored in the class to the events from peak-finding.
2. a fix to the `refine_geometry` task, which simultaneously scans over distance and center. 

(https://xkcd.com/231/)