### PR TITLE
SmallDataReader : Interface for reading/processing small data hdf5 files 

### DIFF
--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -47,7 +47,7 @@ class H5TerminalApp:
 
         # Used to change which keys are shown if not all can be shown at once
         self._rowshift: int = 0
-        self._shiftmax: int = 0
+        self._shiftmax: int = self._calc_shiftmax()
 
         self.main_window.box()
 

--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -86,9 +86,6 @@ class H5TerminalApp:
         display the current text.
         """
         while ((keypress := self.main_window.getch()) != ord('q')):
-            self._update_title_bar()
-            self._refresh(self.title_bar)
-
             self._update_main_window(keypress)
             self._refresh(self.main_window)
 
@@ -125,13 +122,7 @@ class H5TerminalApp:
               keypresses.
         """
         if keypress == ord('d'):
-            keys = self.h5[self._current_dir].keys()
-            item = list(keys)[self.cursor.row - 1]
-            new_path = self._current_dir
-            if new_path == '/':
-                new_path += item
-            else:
-                new_path += '/' + item
+            new_path = self._cursor_over_path()
             if type(self.h5[new_path]) == DATASET:
                 pass
             else:
@@ -166,13 +157,31 @@ class H5TerminalApp:
             pass
 
         elif keypress == ord('1'):
-            pass
+            new_path = self._cursor_over_path()
+            if type(self.h5[new_path]) == DATASET:
+                self.arr1 = self.h5[new_path][()]
 
         elif keypress == ord('2'):
-            pass
+            new_path = self._cursor_over_path()
+            if type(self.h5[new_path]) == DATASET:
+                self.arr2 = self.h5[new_path][()]
 
         self.main_window.move(self.cursor.row, self.cursor.col)
         curses.doupdate()
+
+    def _cursor_over_path(self) -> str:
+        """! Return the path in the hdf5 file that the cursor is over.
+
+        @return new_path (str) The path that the cursor is currently over.
+        """
+        keys = self.h5[self._current_dir].keys()
+        item = list(keys)[self.cursor.row - 1]
+        new_path = self._current_dir
+        if new_path == '/':
+            new_path += item
+        else:
+            new_path += '/' + item
+        return new_path
 
     def _refresh(self, window):
         window.timeout(1)
@@ -189,7 +198,6 @@ class H5TerminalApp:
         self.stdscr.keypad(False)
         curses.echo()
         curses.endwin()
-        #print(self._current_dir)
 
     def __del__(self):
         self.__exit__()

--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -1,6 +1,7 @@
 try:
     import h5py
     import curses
+    import numpy as np
     import matplotlib.pyplot as plt
     import sys
     import time
@@ -12,7 +13,9 @@ except ModuleNotFoundError:
 
 class H5TerminalApp:
     def __init__(self, path: str):
-        self._path = path
+        self._path: str = path
+        self.arr1: np.ndarray = np.zeros([1])
+        self.arr2: np.ndarray = np.zeros([1])
         # Open h5 file
         try:
             self.h5 = h5py.File(path)
@@ -30,7 +33,7 @@ class H5TerminalApp:
         self._cols = curses.COLS
         self._rows = curses.LINES
 
-        self.y_offset = int(self._rows*0.10)
+        self.y_offset: int = int(self._rows*0.10)
         self.title_bar = curses.newwin(self.y_offset, self._cols, 0, 0)
         self.main_window = curses.newwin(self._rows - self.y_offset,
                                          self._cols,
@@ -59,8 +62,8 @@ class H5TerminalApp:
                              xlim = [0, self._cols - 1])
 
         # Cursor positions
-        self.cursor_x = 10
-        self.cursor_y = 10
+        # self.cursor_x: int = 10
+        # self.cursor_y: int = 10
 
         # Display initial text.
         self._update_title_bar()
@@ -95,8 +98,8 @@ class H5TerminalApp:
 
     def _update_main_window(self, keypress):
         curses.curs_set(1)
-        keys = list(self.h5.keys())
-        y = int(self._rows*0.15)
+        keys: list = list(self.h5.keys())
+        y: int = int(self._rows*0.15)
         for i in range(len(keys)):
             self.main_window.addstr(i + 1, 4, keys[i])
         self._update_cursor(keypress)

--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -63,10 +63,6 @@ class H5TerminalApp:
                              ylim = [1, self._rows - self.y_offset - 2],
                              xlim = [0, self._cols - 1])
 
-        # Cursor positions
-        # self.cursor_x: int = 10
-        # self.cursor_y: int = 10
-
         # Display initial text.
         self._update_title_bar()
         self._refresh(self.title_bar)
@@ -103,7 +99,8 @@ class H5TerminalApp:
             self.main_window.clear()
             self.main_window.box()
             for i in range(len(keys)):
-                self.main_window.addstr(i + 1, 4, keys[i])
+                if i < self.cursor.ylim[1]:
+                    self.main_window.addstr(i + 1, 4, keys[i])
             self.update_maintext = False
         self._parse_keypress(keypress)
 
@@ -129,7 +126,8 @@ class H5TerminalApp:
                 self._current_dir = new_path
                 self.update_maintext = True
 
-            ymax: int = len(self.h5[self._current_dir])
+            ymax: int = min(len(self.h5[self._current_dir]),
+                            self._rows - self.y_offset - 2)
             ylims: list = [1, ymax]
             self.cursor.update_limits(ylims, self.cursor.xlim)
 
@@ -143,7 +141,8 @@ class H5TerminalApp:
                     new_path += item
                 self._current_dir = new_path
                 self.update_maintext = True
-                ymax: int = len(self.h5[self._current_dir])
+                ymax: int = min(len(self.h5[self._current_dir]),
+                                self._rows - self.y_offset - 2)
                 ylims: list = [1, ymax]
                 self.cursor.update_limits(ylims, self.cursor.xlim)
 
@@ -250,4 +249,3 @@ class Cursor:
 if __name__ == '__main__':
     app = H5TerminalApp(sys.argv[1])
     app.run()
-

--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -139,7 +139,6 @@ class H5TerminalApp:
             self._shiftmax = self._calc_shiftmax()
 
         elif keypress == ord('a'):
-            keys = self.h5[self._current_dir].keys()
             new_path = '/'
             if self._current_dir == '/':
                 pass

--- a/btx/io/h5terminalapp.py
+++ b/btx/io/h5terminalapp.py
@@ -1,0 +1,179 @@
+try:
+    import h5py
+    import curses
+    import matplotlib.pyplot as plt
+    import sys
+    import time
+
+    DATASET = h5py._hl.dataset.Dataset
+
+except ModuleNotFoundError:
+    print('Cannot run the terminal application. Missing dependencies.')
+
+class H5TerminalApp:
+    def __init__(self, path: str):
+        self._path = path
+        # Open h5 file
+        try:
+            self.h5 = h5py.File(path)
+        except FileNotFoundError:
+            print(f'Small data not found at path: {path}')
+            return
+
+    def run(self):
+        # Curses init
+        self.stdscr = curses.initscr()
+        curses.noecho()
+        curses.cbreak()
+        self.stdscr.keypad(True)
+
+        self._cols = curses.COLS
+        self._rows = curses.LINES
+
+        self.y_offset = int(self._rows*0.10)
+        self.title_bar = curses.newwin(self.y_offset, self._cols, 0, 0)
+        self.main_window = curses.newwin(self._rows - self.y_offset,
+                                         self._cols,
+                                         self.y_offset,
+                                         0)
+
+        # self.title_bar.box()
+        self.main_window.box()
+
+        name = self._path.split('/')[-1]
+        self.title = f'Small Data Explorer - {name}'
+
+        curses.start_color()
+        curses.use_default_colors()
+
+        # Color pair n with foreground f and background b (n, f, b)
+        curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_BLUE)
+
+        # Set background colors of the app
+        self.main_window.bkgd(curses.color_pair(1))
+        self.title_bar.bkgd(curses.color_pair(1))
+
+        self.cursor = Cursor(y = 1,
+                             x = 4,
+                             ylim = [1, self._rows - self.y_offset - 2],
+                             xlim = [0, self._cols - 1])
+
+        # Cursor positions
+        self.cursor_x = 10
+        self.cursor_y = 10
+
+        # Display initial text.
+        self._update_title_bar()
+        self._refresh(self.title_bar)
+
+        self._update_main_window(None)
+        self._refresh(self.main_window)
+
+        # Main event loop
+        self.main_loop()
+
+    def main_loop(self):
+        """! Main event loop.
+
+        Loop condition assigns any keypress to a variable, and breaks if 'q'.
+        Other keypresses will update screen display, otherwise continues to
+        display the current text.
+        """
+        while ((keypress := self.main_window.getch()) != ord('q')):
+            self._update_title_bar()
+            self._refresh(self.title_bar)
+
+            self._update_main_window(keypress)
+            self._refresh(self.main_window)
+
+    def _update_title_bar(self):
+        curses.curs_set(0)
+        x = (self._cols // 2) - (len(self.title) // 2)
+
+        # Add title
+        self.title_bar.addstr(1, x, self.title, curses.color_pair(1))
+
+    def _update_main_window(self, keypress):
+        curses.curs_set(1)
+        keys = list(self.h5.keys())
+        y = int(self._rows*0.15)
+        for i in range(len(keys)):
+            self.main_window.addstr(i + 1, 4, keys[i])
+        self._update_cursor(keypress)
+
+    def _update_cursor(self, keypress):
+        if keypress == ord('d'):
+            # self.cursor.right()
+            pass
+
+        elif keypress == ord('a'):
+            # self.cursor.left()
+            pass
+
+        elif keypress == ord('s'):
+            self.cursor.down()
+
+        elif keypress == ord('w'):
+            self.cursor.up()
+
+        self.main_window.move(self.cursor.row, self.cursor.col)
+        curses.doupdate()
+
+    def _refresh(self, window):
+        window.timeout(1)
+        window.refresh()
+
+    def _cleanup(self, window):
+        window.clear()
+        window.refresh()
+
+    def __exit__(self, *errors):
+        self._cleanup(self.title_bar)
+        self._cleanup(self.main_window )
+        curses.nocbreak()
+        self.stdscr.keypad(False)
+        curses.echo()
+        curses.endwin()
+
+    def __del__(self):
+        self.__exit__()
+
+
+class Cursor:
+    """! Holds the cursor position and limits on where it can move."""
+    def __init__(self, y, x, ylim, xlim):
+        self.row = y
+        self.col = x
+
+        self.ylim = ylim
+        self.xlim = xlim
+
+    def left(self):
+        """! Move cursor position to the left by one."""
+        if self.col > self.xlim[0]:
+            self.col -= 1
+
+    def right(self):
+        """! Move cursor position to the right by one."""
+        if self.col < self.xlim[1]:
+            self.col += 1
+
+    def up(self):
+        """! Move cursor position up by one."""
+        if self.row > self.ylim[0]:
+            self.row -= 1
+
+    def down(self):
+        """! Move cursor position down by one."""
+        if self.row < self.ylim[1]:
+            self.row += 1
+
+    def update_limits(self, ylim, xlim):
+        """! Update the bounds of permitted x, y cursor positions."""
+        self.ylim = ylim
+        self.xlim = xlim
+
+if __name__ == '__main__':
+    app = H5TerminalApp(sys.argv[1])
+    app.run()
+

--- a/btx/io/ih5.py
+++ b/btx/io/ih5.py
@@ -1,12 +1,21 @@
 """!
 @brief Utilities for working with HDF5 files and managing concurrent write operations.
 
+Classes:
+SmallDataReader : Interface to HDF5 files written by Small Data.
+
 Functions:
 lock_file(path, timeout) : Decorator to prevent concurrent write operations.
 """
 
-import os, signal, time
+import os
+import numpy as np
+import signal
+import time
 import h5py
+import tables
+import socket
+import matplotlib.pyplot as plt
 
 def lock_file(path:str, timeout: int = 5, wait: float = 0.5) -> callable:
     """! Decorator mainly for write functions. Will not allow the decorated
@@ -23,7 +32,7 @@ def lock_file(path:str, timeout: int = 5, wait: float = 0.5) -> callable:
     my_write_function() # Create shared.lock if it doesn't exist
 
     @param path (str) Path including filename of the file to be locked.
-    @param timeout (int) The timeout time in seconds to abandon execution attempt.
+    @param timeout (int) Timeout time in seconds to abandon execution attempt.
     @param wait (float) Time in seconds to wait between write attempts.
     """
     def decorator_lock(write_func: callable) -> callable:
@@ -59,10 +68,69 @@ def lock_file(path:str, timeout: int = 5, wait: float = 0.5) -> callable:
         return wrapper
     return decorator_lock
 
+
 def _timeout_handler(signum, frame):
     raise TimeoutError()
 
+
 class TimeoutError(Exception):
     """! Error raised if timeout is reached."""
+
     def __init__(self, msg='Timeout reached'):
+        """! Exception initializer."""
         super().__init__(msg)
+
+
+class SmallDataReader:
+    """! Class interface for reading SmallData hdf5 files."""
+
+    def __init__(self, expmt: str,
+                 run: str | int,
+                 savedir: str,
+                 h5path: str | None = None):
+        """! SmallDataReader initializer.
+
+        @param expmt (str) : Experiment name.
+        @param run (str | int) : Run number or range of hyphen-separated runs.
+        @param savedir (str) : Path to write any output files to.
+        @param h5path (str | None) : Path to an hdf5 file. Will search if None.
+        """
+        if h5path:
+            self._path = h5path
+        else:
+            if 'drp' in socket.gethostname():
+                self._path = (f"/cds/data/drpsrcf/{expmt[:3]}/{expmt}/scratch/"
+                              f"hdf5/smalldata/{expmt}_Run{run:04d}")
+            else:
+                self._path = (f"/cds/data/psdm/{expmt[:3]}/{expmt}/"
+                              f"hdf5/smalldata/{expmt}_Run{run:04d}")
+
+        self.expmt = expmt
+        self.run = run
+        self.savedir = savedir
+
+        self.root = tables.File(self._path).root
+        self.h5 = h5py.File(self._path)
+
+    def timetool_histograms(self):
+        """! Pass."""
+        fltpos_ps = self.h5['tt/FLTPOS_PS'][:]
+        # fltpos = self.h5['tt/FLTPOS'][:]
+        ampl = self.h5['tt/AMPL'][:]
+        fwhm = self.h5['tt/FLTPOSFWHM'][:]
+
+        fig, axs = plt.subplots(1, 3, figsize=(6, 4), dpi=200)
+        # axs[0].hist(fltpos, bins=30)
+        axs[0].hist(fltpos_ps, bins=30, density=True)
+        axs[0].set_title('Timetool Correction')
+        axs[0].set_xlabel('Correction (ps)')
+        axs[0].set_ylabel('Density')
+        # axs[0].hist(fltpos)
+        axs[1].hist(ampl, bins=30, density=True)
+        axs[1].set_title('Convolution\nAmplitude')
+        axs[1].set_xlabel('Amplitude (a.u.)')
+        axs[2].hist(fwhm, bins=30, density=True)
+        axs[2].set_title('Convolution FWHM')
+        axs[2].set_xlabel('FWHM (a.u.)')
+        fig.tight_layout()
+        fig.savefig(f'{self.savedir}/tt_histograms_r{self.run:04d}.png')

--- a/btx/io/ih5.py
+++ b/btx/io/ih5.py
@@ -16,6 +16,7 @@ import h5py
 import tables
 import socket
 import matplotlib.pyplot as plt
+from typing import Union, Optional
 
 def lock_file(path:str, timeout: int = 5, wait: float = 0.5) -> callable:
     """! Decorator mainly for write functions. Will not allow the decorated
@@ -85,9 +86,9 @@ class SmallDataReader:
     """! Class interface for reading SmallData hdf5 files."""
 
     def __init__(self, expmt: str,
-                 run: str | int,
+                 run: Union[str, int],
                  savedir: str,
-                 h5path: str | None = None):
+                 h5path: Optional[str] = None):
         """! SmallDataReader initializer.
 
         @param expmt (str) : Experiment name.
@@ -112,20 +113,48 @@ class SmallDataReader:
         self.root = tables.File(self._path).root
         self.h5 = h5py.File(self._path)
 
+    def image_sums(self):
+        """! Plots the sums of the images over a run for the used detectors.
+
+        The image sums (powder patterns for crystallography) can be used to
+        verify that data was collected during a run.
+        """
+        imgList = [self.h5[f'Sums/{img}'] for img in self.h5['Sums'].keys()]
+
+        for img in imgList:
+            squeezed = img[:].squeeze()
+            if len(squeezed.shape) > 2:
+                self.construct_img_panels(img)
+            else:
+                lims = (np.nanpercentile(squeezed, 5),
+                        np.nanpercentile(squeezed, 95))
+                title = img.name.split('/')[2]
+                fig, ax = plt.subplots(1, 1, figsize=(4, 4), dpi=200)
+                ax.imshow(squeezed, clim=lims)
+                ax.set_title(title)
+                fig.tight_layout()
+                fig.savefig(f'{self.savedir}/{title}_Sum_r{self.run:04d}')
+
+    def construct_img_panels(self):
+        """! Assemble multipanel detector images."""
+        pass
+
     def timetool_histograms(self):
-        """! Pass."""
+        """! Plot histograms of timetool output.
+
+        Plots the histograms of: the timetool correction, the convolution
+        amplitudes, and the full-width half-maximums (FWHMs) of the
+        convolutions.
+        """
         fltpos_ps = self.h5['tt/FLTPOS_PS'][:]
-        # fltpos = self.h5['tt/FLTPOS'][:]
         ampl = self.h5['tt/AMPL'][:]
         fwhm = self.h5['tt/FLTPOSFWHM'][:]
 
         fig, axs = plt.subplots(1, 3, figsize=(6, 4), dpi=200)
-        # axs[0].hist(fltpos, bins=30)
         axs[0].hist(fltpos_ps, bins=30, density=True)
         axs[0].set_title('Timetool Correction')
         axs[0].set_xlabel('Correction (ps)')
         axs[0].set_ylabel('Density')
-        # axs[0].hist(fltpos)
         axs[1].hist(ampl, bins=30, density=True)
         axs[1].set_title('Convolution\nAmplitude')
         axs[1].set_xlabel('Amplitude (a.u.)')
@@ -134,3 +163,34 @@ class SmallDataReader:
         axs[2].set_xlabel('FWHM (a.u.)')
         fig.tight_layout()
         fig.savefig(f'{self.savedir}/tt_histograms_r{self.run:04d}.png')
+
+    def print_all_nodes(self):
+        """! Print all groups and datasets in the HDF5 file."""
+        self.traverse_nodes(self.h5, level=1)
+
+    def traverse_nodes(self, node, level: int = 1):
+        """! Recurses through an HDF5 file hierarchy printing nodes."""
+        if type(node) == h5py._hl.dataset.Dataset:
+            return
+        else:
+            for key in node.keys():
+                print('\t'*(level - 1) + f'{key}\n')
+                self.traverse_nodes(node[key], level=level + 1)
+
+    def write_stamped_values(self, node_list: list):
+        """! Write a text file of unique event identifiers and h5 node values.
+
+        This can be used to write out e.g. specific evr codes per event. Data
+        is written in a space separated format, with one event per line. The
+        first column contains event identifiers, followed by the values for
+        each node in subsequent columns. E.g.:
+        unique-identifier node1        node2 ...
+                id_event1 event1-node1 event1-node2
+                id_event2 event2-node1 event2-node2
+                   ...
+
+        Unique identifiers are of the form: `event_time-fiducial`
+
+        @param node_list (list[str])
+        """
+        pass

--- a/btx/io/ih5.py
+++ b/btx/io/ih5.py
@@ -6,9 +6,12 @@ SmallDataReader : Interface to HDF5 files written by Small Data.
 
 Functions:
 lock_file(path, timeout) : Decorator to prevent concurrent write operations.
+figure_to_array(figure) : Convert a plt.Figure to np.ndarray for storage in h5.
+array_to_figure(figure) : Convert a np.ndarray back into a plt.Figure.
 """
 
 import os
+from types import prepare_class
 import numpy as np
 import signal
 import time
@@ -17,6 +20,7 @@ import tables
 import socket
 import matplotlib.pyplot as plt
 from typing import Union, Optional, Callable, Any
+from .h5terminalapp import *
 
 def lock_file(path:str, timeout: int = 5, wait: float = 0.5) -> Callable:
     """! Decorator mainly for write functions. Will not allow the decorated
@@ -82,8 +86,52 @@ class TimeoutError(Exception):
         super().__init__(msg)
 
 
+def figure_to_array(self, figure: plt.Figure) -> np.ndarray:
+    """! Convert a matplotlib Figure object to an array.
+
+    Converting a figure to an array allows for simpler storage of the
+    data in an hdf5 file. A sister method `array_to_figure` performs the
+    reverse operation.
+
+    @param figure (plt.Figure) : Figure in plt.Figure form to convert.
+    @return figArr (np.ndarray) : Figre in np.ndarray form.
+    """
+    from matplotlib.backend.backend_agg import FigureCanvasAgg
+    canvas = FigureCanvasAgg(figure)
+    canvas.draw()
+
+    figArr = np.asarray(canvas.buffer_rgba())
+    return figArr
+
+
+def array_to_figure(self, figArr: np.ndarray) -> plt.Figure:
+    """! Convert a Numpy array into a matplotlib Figure.
+
+    Converts a previously converted matplotlib Figure from an array back
+    into a Figure either to facilitate display for to allow the figure
+    to be stored in another format.
+
+    @param figArr (np.ndarray) : Figure in array form to convert.
+    @return figure (plt.Figure) : Figure in plt.Figure form.
+    """
+    figure = plt.Figure()
+    ax = figure.add_subplot(111)
+    ax.imshow(figArr)
+    return figure
+
+
 class SmallDataReader:
-    """! Class interface for reading SmallData hdf5 files."""
+    """! Class interface for reading SmallData hdf5 files.
+
+    This class defines simple utilities for interacting with data stored in
+    hdf5 files. Plotting methods are provided for frequently used categories
+    of data. Plots can be output as png files or have their data saved to a
+    common hdf5 file to simplify house keeping. Methods for storing and
+    retrieving figure/plot data from hdf5 files are provided, along with
+    general methods for interacting with the hdf5 file system. SmallDataReader
+    instances can also be subscripted identically to h5py File objects to
+    directly access stored data.
+    """
 
     def __init__(self, expmt: str,
                  run: Union[str, int],
@@ -101,10 +149,10 @@ class SmallDataReader:
         else:
             if 'drp' in socket.gethostname():
                 self._path = (f"/cds/data/drpsrcf/{expmt[:3]}/{expmt}/scratch/"
-                              f"hdf5/smalldata/{expmt}_Run{run:04d}")
+                              f"hdf5/smalldata/{expmt}_Run{int(run):04d}")
             else:
                 self._path = (f"/cds/data/psdm/{expmt[:3]}/{expmt}/"
-                              f"hdf5/smalldata/{expmt}_Run{run:04d}")
+                              f"hdf5/smalldata/{expmt}_Run{int(run):04d}")
 
         self.expmt = expmt
         self.run = run
@@ -116,7 +164,107 @@ class SmallDataReader:
         except FileNotFoundError:
             print("No small data available for this run.")
 
-    def image_sums(self):
+    def write_to_node(self, h5file: str, node: str, data: np.ndarray):
+        """! Write data to an HDF5 node.
+
+        Check if the node exists before writing. If so, alter the data,
+        otherwise create the node with the data. This method exists to provide
+        the boilerplate existence check when writing to a node.
+
+        @param h5file (str) : File to write to.
+        @param node (str) : Full path of the node to be written to.
+        @param data (array-like) : Data to write to the file.
+        """
+        with h5py.File(f'{h5file}', 'w') as f:
+            if node in f:
+                f[node].data = data
+            else:
+                f[node] = data
+
+    def print_all_nodes(self):
+        """! Print all groups and datasets in the HDF5 file."""
+        self.traverse_nodes(self.h5, level=1)
+
+    def traverse_nodes(self, node, level: int = 1):
+        """! Recurses through an HDF5 file hierarchy printing nodes."""
+        if type(node) == h5py._hl.dataset.Dataset:
+            return
+        else:
+            for key in node.keys():
+                print('\t'*(level - 1) + f'{key}\n')
+                self.traverse_nodes(node[key], level=level + 1)
+
+    def timestamped_data_totext(self, node_list: list, filename: str):
+        """! Write a text file of unique event identifiers and h5 node values.
+
+        This can be used to write out e.g. specific evr codes per event. Data
+        is written in a space separated format, with one event per line. The
+        first column contains event identifiers, followed by the values for
+        each node in subsequent columns. E.g.:
+        unique-identifier node1        node2        ...
+                id_event1 event1-node1 event1-node2
+                id_event2 event2-node1 event2-node2
+                   ...
+
+        Unique identifiers are of the form: `event_time-fiducial`
+
+        @param node_list (list[str]) List of hdf5 nodes to write to text.
+        @param filename (str) Filename to write the text file to.
+        """
+        stamps = self.unique_stamps()
+        info_to_write = [stamps]
+        for node in node_list:
+            if node in self.h5:
+                info_to_write.append(self.h5[node])
+            else:
+                print(f'Ignoring node: {node}. Not in small data.')
+
+        info_to_write = np.array(info_to_write).T
+        np.savetext(f'{self.savedir}/{filename}', '%s')
+
+
+    def unique_stamps(self) -> np.ndarray:
+        """! Combine timestamps and fiducials for unique event identifiers."""
+        stamps = list(map(lambda x, y: f'{x}-{y}',
+                          self.h5['event_time'][:],
+                          self.h5['fiducials']))
+        return np.array(stamps)
+
+    def h5_explorer(self):
+        """! Interactive exploration of the small data hdf5.
+
+        Launch a terminal program for viewing groups and datasets.
+        Can ONLY be used when running Python in calculator mode in terminal.
+        This method does not behave properly in Jupyter Notebooks.
+        """
+        try:
+            app = H5TerminalApp(self._path)
+            app.run()
+        except Exception as e:
+            print(e)
+
+    def __getitem__(self, key: str) -> Any:
+        """! Overload subscripting operator, [], to access hdf5 file.
+
+        @param key (str) : Node to access.
+        @return value (Any) : The value living at the specified key in the hdf5.
+        """
+        try:
+            return self.h5[key]
+        except KeyError:
+            print(f'Incorrect node: {key}.')
+
+    def __setitem__(self, key: str, value: Any):
+        """! Provided only to prevent accidental errors."""
+        print('Writing to hdf5 prohibited.')
+
+    # Task specific plotting functions
+    # - One plotting method per task
+    # - Also one plotting method per figure
+    # - If a task requires multiple figures, call the multiple figure methods
+    #   from the 'task' method. See plot_timetool_diagnostics for example.
+    #########################################################################
+    def plot_image_sums(self, output_type: str = 'png'):
         """! Plots the sums of the images over a run for the used detectors.
 
         The image sums (powder patterns for crystallography) can be used to
@@ -144,15 +292,27 @@ class SmallDataReader:
 
 
     def construct_img_panels(self):
-        """! Assemble multipanel detector images."""
+        """! Assemble multipanel detector images for plotting."""
         pass
 
-    def timetool_histograms(self):
+    def plot_timetool_diagnostics(self, output_type: str = 'png'):
+        """! Calls all timetool related plotting functions.
+
+        Plots can be written out to png figures or stored in an hdf5 file.
+
+       @param output_type (str) : Output format for plots. Either h5 or png.
+        """
+        self.plot_timetool_histograms(output_type)
+        self.plot_timetool_amplitude_correlation(output_type)
+
+    def plot_timetool_histograms(self, output_type: str = 'png'):
         """! Plot histograms of timetool output.
 
         Plots the histograms of: the timetool correction, the convolution
         amplitudes, and the full-width half-maximums (FWHMs) of the
         convolutions.
+
+        @param output_type (str) : Output format for plots. Either h5 or png.
         """
         if 'tt' in self.h5:
             fltpos_ps = self.h5['tt/FLTPOS_PS'][:]
@@ -171,11 +331,16 @@ class SmallDataReader:
             axs[2].set_title('Convolution FWHM')
             axs[2].set_xlabel('FWHM (a.u.)')
             fig.tight_layout()
-            fig.savefig(f'{self.savedir}/ttHistograms_r{self.run:04d}.png')
+            if output_type.lower() == 'png':
+                fig.savefig(f'{self.savedir}/ttHistograms_r{self.run:04d}.png')
+            elif output_type.lower() == 'h5':
+                pass
         else:
             print('No timetool data available.')
 
-    def timetool_amplitude_correlation(self, xrayinode: Optional[str] = None):
+    def plot_timetool_amplitude_correlation(self,
+                                            xrayinode: Optional[str] = None,
+                                            output_type: str = 'h5'):
         """! Plot the 2D histogram of x-ray intensity and convolution amplitude.
 
         The timetool convolution amplitude should be correlated with the x-ray
@@ -184,6 +349,7 @@ class SmallDataReader:
         to be ~linear.
 
         @param xrayinode (str) : Specific node with X-ray intensity recordings.
+        @param output_type (str) : Output format for plots. Either h5 or png.
         """
         try:
             ampl = self.h5['tt/AMPL'][:]
@@ -195,13 +361,17 @@ class SmallDataReader:
             else:
                 xray_i = []
 
-            if len(xray_i) > 0: # Test length explicitly when ndarray (ie not list)
+            if len(xray_i) > 0:
                 fig, ax = plt.subplots(1, 1, figsize=(3, 3), dpi=200)
                 ax.hexbin(xray_i, ampl, mincnt=1)
                 ax.set_xlabel('X-ray Intensity')
                 ax.set_ylabel('Timetool Convolution Amplitude')
                 fig.tight_layout()
-                fig.savefig(f'{self.savedir}/ttAmplXrayICorr_r{self.run:04d}.png')
+                if output_type.lower() =='png':
+                    fig.savefig(f'{self.savedir}/ttAmplXrayICorr_r{self.run:04d}.png')
+                elif output_type.lower() == 'h5':
+                    pass
+
         except KeyError as err:
             print(f'Node not found: {str(err).split()[6]}')
 
@@ -212,53 +382,5 @@ class SmallDataReader:
         # keys is an empty list if no nodes found
         return keys
 
-    def print_all_nodes(self):
-        """! Print all groups and datasets in the HDF5 file."""
-        self.traverse_nodes(self.h5, level=1)
-
-    def traverse_nodes(self, node, level: int = 1):
-        """! Recurses through an HDF5 file hierarchy printing nodes."""
-        if type(node) == h5py._hl.dataset.Dataset:
-            return
-        else:
-            for key in node.keys():
-                print('\t'*(level - 1) + f'{key}\n')
-                self.traverse_nodes(node[key], level=level + 1)
-
-    def timestamped_data_totext(self, node_list: list):
-        """! Write a text file of unique event identifiers and h5 node values.
-
-        This can be used to write out e.g. specific evr codes per event. Data
-        is written in a space separated format, with one event per line. The
-        first column contains event identifiers, followed by the values for
-        each node in subsequent columns. E.g.:
-        unique-identifier node1        node2        ...
-                id_event1 event1-node1 event1-node2
-                id_event2 event2-node1 event2-node2
-                   ...
-
-        Unique identifiers are of the form: `event_time-fiducial`
-
-        @param node_list (list[str])
-        """
-        pass
 
 
-    def unique_stamps(self):
-        """! Combine timestamps and fiducials for unique event identifiers."""
-        pass
-
-    def __getitem__(self, key: str) -> Any:
-        """! Overload subscripting operator, [], to access hdf5 file.
-
-        @param key (str) : Node to access.
-        @return value (Any) : The value living at the specified key in the hdf5.
-        """
-        try:
-            return self.h5[key]
-        except KeyError:
-            print('Incorrect node.')
-
-    def __setitem__(self, key, value):
-        """! Provided only to prevent accidental errors."""
-        print('Writing to hdf5 prohibited.')

--- a/btx/io/ih5.py
+++ b/btx/io/ih5.py
@@ -222,12 +222,11 @@ class SmallDataReader:
         info_to_write = np.array(info_to_write).T
         np.savetext(f'{self.savedir}/{filename}', '%s')
 
-
     def unique_stamps(self) -> np.ndarray:
         """! Combine timestamps and fiducials for unique event identifiers."""
         stamps = list(map(lambda x, y: f'{x}-{y}',
                           self.h5['event_time'][:],
-                          self.h5['fiducials']))
+                          self.h5['fiducials'][:]))
         return np.array(stamps)
 
     def h5_explorer(self):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -358,6 +358,23 @@ def clean_up(config):
         os.system(f"rm -f {taskdir}/r*/*{task.tag}.cxi")
     logger.debug('Done!')
 
+def timetool_diagnostics(config):
+    """! Plot timetool diagnostic figures from data in smalldata hdf5 file."""
+    from btx.io.ih5 import SmallDataReader
+    setup = config.setup
+    task = config.timetool_diagnostics
+    savedir = os.path.join(setup.root_dir, 'timetool')
+
+    expmt = setup.exp
+    run = setup.run
+
+    if not task.h5:
+        smdr = SmallDataReader(expmt, run, savedir)
+    else:
+        smdr = SmallDataReader(expmt, run, savedir, task.h5)
+
+    smdr.plot_timetool_diagnostics(output_type = 'png')
+
 def calibrate_timetool(config):
     from btx.processing.rawimagetimetool import RawImageTimeTool
     setup = config.setup


### PR DESCRIPTION
This PR intends to provide a high-level interface to data written to small data h5 files.

This has two primary functions:
- Node access : Viewing file hierarchy, and selecting specific data from the hdf5
- Basic figure generation : Plotting of diagnostics from the data written to the hdf5 files.

### Node exploration

### Figure generation
This should simplify plotting of certain data, e.g. ROIs, timing data, xray/laser on/off status per event, as all this data is already written to the small data files. Tasks can be defined in a simple manner using the `SmallDataReader`. All the details are abstracted away into the relevant methods. As the data is already in an hdf5 file, these tasks are *faster* than going through `psana`.

For example, to get timetool diagnostics:

```py
def timetool_diagnostics(config):
    """! Plot timetool diagnostic figures from data in smalldata hdf5 file."""
    from btx.io.ih5 import SmallDataReader
    setup = config.setup
    task = config.timetool_diagnostics
    savedir = os.path.join(setup.root_dir, 'timetool')

    expmt = setup.exp
    run = setup.run

    if not task.h5:
        smdr = SmallDataReader(expmt, run, savedir)
    else:
        smdr = SmallDataReader(expmt, run, savedir, task.h5)

    smdr.plot_timetool_diagnostics(output_type = 'png')
```