### PR TITLE
Correct URL on JID, update python on elog_trigger

### DIFF
--- a/dags/plugins/jid.py
+++ b/dags/plugins/jid.py
@@ -22,7 +22,7 @@ class JIDSlurmOperator( BaseOperator ):
     'SLAC': "http://psdm02:8446/jid_slac/jid/ws/",
     'SRCF_FFB': "http://drp-srcf-mds001:8446/jid_srcf_ffb/jid/ws/",
     'NERSC': "http://psdm02:8446/jid_nersc/jid/ws/",
-    'S3DF' : "https://psdm.slac.stanford.edu/arps3dfjid/ws/"
+    'S3DF' : "https://psdm.slac.stanford.edu/arps3dfjid/jid/ws/"
   }
 
   btx_locations = {

--- a/scripts/elog_trigger.py
+++ b/scripts/elog_trigger.py
@@ -1,4 +1,4 @@
-#!/reg/g/psdm/sw/dm/conda/envs/psdm_ws_0_0_9/bin/python3
+#!/sdf/group/lcls/ds/ana/sw/conda1/inst/envs/ana-4.0.47-py3/bin/python
 
 import os
 import logging


### PR DESCRIPTION
Corrections for Airflow use on S3DF:
- ARP_API_ENDPOINT URL correction
- `elog_trigger` shebang points to actual Python version on S3DF