### PR TITLE
Fix btx path for use with Airflow

### DIFF
--- a/dags/plugins/jid.py
+++ b/dags/plugins/jid.py
@@ -29,7 +29,7 @@ class JIDSlurmOperator( BaseOperator ):
     'SLAC': "/cds/sw/package/autosfx/btx/",
     'SRCF_FFB': "/cds/sw/package/autosfx/btx/",
     'NERSC': "/global/cfs/cdirs/lcls/btx/",
-    'S3DF' : "/sdf/group/lcls/ds/tools/btx"
+    'S3DF' : "/sdf/group/lcls/ds/tools/btx/"
   }
   # "/sdf/group/lcls/ds/sw/autosfx/btx/",
 


### PR DESCRIPTION
Change
- Add final "/ "to `btx_locations['S3DF']` path

Needed to correctly locate `elog_submit`