### PR TITLE
Copystat patch

### DIFF
--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -7,6 +7,7 @@ import sys
 import os
 import time
 import yaml
+import errno
 from btx.misc.shortcuts import AttrDict
 from btx.misc.metrology import offset_geom
 from btx.interfaces.istream import *
@@ -262,7 +263,11 @@ class Geoptimizer:
         for opt,new in zip([geom_opt,cell_opt,mtz_opt],[geom_new,cell_new,mtz_new]):
             if os.path.exists(new):
                 shutil.move(new, f"{new}.old")
-            shutil.copy2(opt, new)
+            try:
+                shutil.copy2(opt, new)
+            except OSError as err:
+                if err.errno != errno.EPERM:
+                    raise
 
     def save_results(self, root_dir, tag, savepath=None, metric='Rsplit'):
         """

--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -7,7 +7,6 @@ import sys
 import os
 import time
 import yaml
-import errno
 from btx.misc.shortcuts import AttrDict
 from btx.misc.metrology import offset_geom
 from btx.interfaces.istream import *
@@ -263,11 +262,7 @@ class Geoptimizer:
         for opt,new in zip([geom_opt,cell_opt,mtz_opt],[geom_new,cell_new,mtz_new]):
             if os.path.exists(new):
                 shutil.move(new, f"{new}.old")
-            try:
-                shutil.copy2(opt, new)
-            except OSError as err:
-                if err.errno != errno.EPERM:
-                    raise
+            shutil.copyfile(opt, new)
 
     def save_results(self, root_dir, tag, savepath=None, metric='Rsplit'):
         """

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -42,7 +42,11 @@ class eLogInterface:
         for filetype in ['pdb', 'mtz']:
             if os.path.isfile(f'{source_dir}final.{filetype}'):
                 os.makedirs(target_dir, exist_ok=True)
-                shutil.copy2(f'{source_dir}final.{filetype}', f'{target_dir}final.{filetype}')
+                try:
+                    shutil.copy2(f'{source_dir}final.{filetype}', f'{target_dir}final.{filetype}')
+                except OSError as err:
+                    if err.errno != errno.EPERM:
+                        raise
 
     def update_html(self, png_list, subdir):
         with open(f'{self.target_dir(subdir=f"{subdir}")}report.html', 'w') as hfile:

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 import shutil
-import errno
 from glob import glob
 
 class eLogInterface:
@@ -42,11 +41,7 @@ class eLogInterface:
         for filetype in ['pdb', 'mtz']:
             if os.path.isfile(f'{source_dir}final.{filetype}'):
                 os.makedirs(target_dir, exist_ok=True)
-                try:
-                    shutil.copy2(f'{source_dir}final.{filetype}', f'{target_dir}final.{filetype}')
-                except OSError as err:
-                    if err.errno != errno.EPERM:
-                        raise
+                shutil.copyfile(f'{source_dir}final.{filetype}', f'{target_dir}final.{filetype}')
 
     def update_html(self, png_list, subdir):
         with open(f'{self.target_dir(subdir=f"{subdir}")}report.html', 'w') as hfile:
@@ -76,11 +71,7 @@ class eLogInterface:
         source_path = f'{self.source_dir(subdir=f"{source_subdir}")}{source_filename}'
         target_path = f'{self.target_dir(subdir=f"{target_subdir}")}{image}.png'
         if os.path.isfile(source_path):
-            try:
-                shutil.copy2(source_path, target_path)
-            except OSError as err:
-                if err.errno != errno.EPERM:
-                    raise
+            shutil.copyfile(source_path, target_path)
 
     def btx_dir(self, subdir=''):
         import btx

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import sys
 import requests
-import errno
 from btx.interfaces.ischeduler import *
 from btx.interfaces.istream import read_cell_file
 from btx.interfaces.imtz import *
@@ -208,12 +207,8 @@ class StreamtoMtz:
 
         # transfer mtz to new folder
         if self.mtz_dir is not None:
-            try:
-                shutil.copy2(os.path.join(self.taskdir, f"{self.prefix}.mtz"), 
-                             os.path.join(self.mtz_dir, f"{self.prefix}.mtz"))
-            except OSError as err:
-                if err.errno != errno.EPERM:
-                    raise
+            shutil.copyfile(os.path.join(self.taskdir, f"{self.prefix}.mtz"), 
+                            os.path.join(self.mtz_dir, f"{self.prefix}.mtz"))
 
 def wrangle_shells_dat(shells_file, outfile=None):
     """

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 import requests
+import errno
 from btx.interfaces.ischeduler import *
 from btx.interfaces.istream import read_cell_file
 from btx.interfaces.imtz import *
@@ -207,8 +208,12 @@ class StreamtoMtz:
 
         # transfer mtz to new folder
         if self.mtz_dir is not None:
-            shutil.copy2(os.path.join(self.taskdir, f"{self.prefix}.mtz"), 
-                         os.path.join(self.mtz_dir, f"{self.prefix}.mtz"))
+            try:
+                shutil.copy2(os.path.join(self.taskdir, f"{self.prefix}.mtz"), 
+                             os.path.join(self.mtz_dir, f"{self.prefix}.mtz"))
+            except OSError as err:
+                if err.errno != errno.EPERM:
+                    raise
 
 def wrangle_shells_dat(shells_file, outfile=None):
     """

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import traceback
 import yaml
-import errno
+import os
 
 from btx.misc.shortcuts import AttrDict
 from scripts.tasks import *
@@ -27,13 +27,13 @@ def main():
         print(f"Error: cannot create root path.") 
         return -1 
 
-    try:
-        # Copy config file to output directory.
-        shutil.copy2(config_filepath, config.setup.root_dir)
-        # Call 'task' function if it exists.
-    except OSError as err:
-        if err.errno != errno.EPERM:
-            raise
+    path_plus_file = config.setup.root_dir + '/' + config_filepath.split('/')[-1]
+    if os.path.exists(path_plus_file):
+        os.remove(path_plus_file)
+        
+    # Copy config file to output directory.
+    shutil.copy2(config_filepath, config.setup.root_dir)
+    # Call 'task' function if it exists.
         
     try:
         globals()[task]

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import traceback
 import yaml
+import errno
 
 from btx.misc.shortcuts import AttrDict
 from scripts.tasks import *
@@ -26,9 +27,14 @@ def main():
         print(f"Error: cannot create root path.") 
         return -1 
 
-    # Copy config file to output directory.
-    shutil.copy2(config_filepath, config.setup.root_dir)
-    # Call 'task' function if it exists.
+    try:
+        # Copy config file to output directory.
+        shutil.copy2(config_filepath, config.setup.root_dir)
+        # Call 'task' function if it exists.
+    except OSError as err:
+        if err.errno != errno.EPERM:
+            raise
+        
     try:
         globals()[task]
     except Exception as e:


### PR DESCRIPTION
Change Log
------------
- Switch to `copyfile` in most places
- Delete old file before copying in `main.py`

Should address the chmod/copystat permission errors that occur when multiple users try to re-run the same analysis sequentially. This may also close #125.

The issues arise in copying metadata and attempting to change permissions which occur when using the `shutil.copy` or `shutil.copy2` high-level copy routines. Most user accounts are not allowed to perform those operations on files they are not the owners of.