### PR TITLE
Bug fixes for ipsana/run_analysis

### DIFF
--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -389,8 +389,9 @@ def retrieve_pixel_index_map(geom):
 
     Returns
     -------
-    pixel_index_map : numpy.ndarray, 4d
+    pixel_index_map : numpy.ndarray, 4d or 5d
         pixel coordinates, shape (n_panels, fs_panel_shape, ss_panel_shape, 2)
+                           shape (pidx1, pidx2, fs_shape, ss_shape, 2)
     """
     if type(geom) == str:
         geom = GeometryAccess(geom)

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -440,13 +440,14 @@ def assemble_image_stack_batch(image_stack, pixel_index_map):
     images = np.zeros((stack_num, index_max_x, index_max_y))
 
     if multiple_panel_dimensions:
-        panel_dim1 = pixel_index_map.shape[0]
-        panel_dim2 = pixel_index_map.shape[1]
-        for i in range(panel_dim1):
-            for j in range(panel_dim2):
+        pdim1 = pixel_index_map.shape[0]
+        pdim2 = pixel_index_map.shape[1]
+        for i in range(pdim1):
+            for j in range(pdim2):
                 x = pixel_index_map[i, j, ..., 0]
                 y = pixel_index_map[i, j, ..., 1]
-                images[:, x, y] = image_stack[:, i, j]
+                idx = i*pdim2 + j
+                images[:, x, y] = image_stack[:, idx]
     else:
         panel_num = image_stack.shape[1]
         # loop through the panels

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -425,7 +425,8 @@ def assemble_image_stack_batch(image_stack, pixel_index_map):
     multiple_panel_dimensions = False
     if len(image_stack.shape) == 3:
         image_stack = np.expand_dims(image_stack, 0)
-    elif len(image_stack.shape) == 5:
+
+    if len(pixel_index_map.shape) == 5:
         multiple_panel_dimensions = True
         
     # get boundary
@@ -438,8 +439,8 @@ def assemble_image_stack_batch(image_stack, pixel_index_map):
     images = np.zeros((stack_num, index_max_x, index_max_y))
 
     if multiple_panel_dimensions:
-        panel_dim1 = image_stack.shape[1]
-        panel_dim2 = image_stack.shape[2]
+        panel_dim1 = pixel_index_map.shape[0]
+        panel_dim2 = pixel_index_map.shape[1]
         for i in range(panel_dim1):
             for j in range(panel_dim2):
                 x = pixel_index_map[i, j, ..., 0]

--- a/btx/interfaces/ipsana.py
+++ b/btx/interfaces/ipsana.py
@@ -227,6 +227,8 @@ class PsanaInterface:
         if pv_beam_transmission is None:
             if self.hutch == 'mfx':
                 pv_beam_transmission = "MFX:ATT:COM:R_CUR"
+            elif self.hutch == 'cxi':
+                pv_beam_transmission = "CXI:DIA:ATT:COM:R_CUR"
             else:
                 raise NotImplementedError
 
@@ -395,8 +397,8 @@ def retrieve_pixel_index_map(geom):
 
     temp_index = [np.asarray(t) for t in geom.get_pixel_coord_indexes()]
     pixel_index_map = np.zeros((np.array(temp_index).shape[2:]) + (2,))
-    pixel_index_map[:,:,:,0] = temp_index[0][0]
-    pixel_index_map[:,:,:,1] = temp_index[1][0]
+    pixel_index_map[...,0] = temp_index[0][0]
+    pixel_index_map[...,1] = temp_index[1][0]
     
     return pixel_index_map.astype(np.int64)
 
@@ -424,8 +426,8 @@ def assemble_image_stack_batch(image_stack, pixel_index_map):
         image_stack = np.expand_dims(image_stack, 0)
 
     # get boundary
-    index_max_x = np.max(pixel_index_map[:, :, :, 0]) + 1
-    index_max_y = np.max(pixel_index_map[:, :, :, 1]) + 1
+    index_max_x = np.max(pixel_index_map[..., 0]) + 1
+    index_max_y = np.max(pixel_index_map[..., 1]) + 1
     # get stack number and panel number
     stack_num = image_stack.shape[0]
     panel_num = image_stack.shape[1]


### PR DESCRIPTION
The following minor changes attempt to address issues with cross-hutch compatibility and detector handling. Data from different detectors and, sometimes, for the same detector in different hutches can come in a format that is not currently handled by `ipsana`. The issue appears to arise from a mismatch between image shapes returned by `psana.Detector` and the pixel index coordinates returned by `PSCalib.GeometryAccess.GeometryAccess`. Additionally, beam transmission PVs were only handled for MFX.

Related to #273 (previously closed)

Change log
----------------
- Address error handling for beam energy/transmission
- Add corresponding CXI PV for beam transmission.
  - This is is a stop-gap and should be handled in a more general way moving forward. Perhaps smalldata deals with some of this?
- Deal with detector data where geometry data about pixel indices has multiple dimensions describing the panels. E.g. `(pidx1, pidx2, fs_shape, ss_shape, ...)` instead of `(n_panels, fs_shape, ss_shape, ...)`