### PR TITLE
interactive plotting of `run_analysis`

### DIFF
--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -471,7 +471,7 @@ class RunDiagnostics:
 
         df = pd.DataFrame({
             'evt_id' : np.arange(y.shape[0]), 
-            'y' : self.stats_final[y_key], 
+            'y' : y, 
             'color_by' : self.stats_final[color_by]})
         scatter = hv.Scatter(df, kdims=['evt_id'], vdims=['y', 'color_by'])
         return scatter.opts(opts.Scatter(tools=['hover'])).opts(width=800, color_index='color_by')


### PR DESCRIPTION
# Changes

**To be discussed:** 
I commented out the `self.n_empty` and `self.n_excluded` parts since they screwed up our ability to retrieve events based on indices.

**Added:**
- ability to load stats if they have been saved already.
- interactive display of stats
- plotting tool to display the detector image for a given event index.

# Usage

In a notebook, import necessary `btx` tools
```python
import sys
btx_path="/sdf/home/f/fpoitevi/sw/btx"
sys.path.append(btx_path)
from btx.diagnostics.run import RunDiagnostics
```

## Compute stats

```python
expt='mfxp23120'
run=8
det_type='epix10k2M'

rd = RunDiagnostics(expt, run, det_type)
rd.compute_run_stats(max_events=-1)
rd.save_traces('./')
```
We provide a static display of the resulting stats:
```python
rd.visualize_stats()
```
![image](https://github.com/lcls-users/btx/assets/4610338/5e29ea24-3f00-4dc4-b1b8-10b9b02110c4)


## Interactive display
One can load the traces if they already exist
```python
rd.load_traces('./')
```
And choose to plot one of them, colored by another one:
```python
rd.visualize_stats_interactive(y_key='mean', color_by='beam_energy_eV')
```
![image](https://github.com/lcls-users/btx/assets/4610338/c6233507-aa3b-43b0-9620-e67e5a77a1ab)
This allows to zoom in and out particular areas of the run:
![image](https://github.com/lcls-users/btx/assets/4610338/4a399dc9-905e-4760-b81f-63307062077a)
Individual events can then be chosen and the corresponding detector image displayed:
```python
rd.display_img_evt(28915)
```
![image](https://github.com/lcls-users/btx/assets/4610338/798234c7-3213-4a84-9439-13bb03787c5a)



