### PR TITLE
Single File Per Run for eLog Report

### DIFF
--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -5,6 +5,9 @@ from glob import glob
 import json
 import requests
 from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 def elog_report_post(summary_file: str, update_url: Optional[str] = None):
     """! Post a summary file to the eLog's run report section.
@@ -20,6 +23,8 @@ def elog_report_post(summary_file: str, update_url: Optional[str] = None):
             url = os.environ.get('JID_UPDATE_COUNTERS')
             if url:
                 requests.post(url, json = post_list)
+            else:
+                logger.warning('WARNING: JID_UPDATE_COUNTERS url not found.')
         else:
             requests.post(update_url, json = post_list)
 

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -4,18 +4,25 @@ import shutil
 from glob import glob
 import json
 import requests
+from typing import Optional
 
-def elog_report_post(summary_file: str, update_url: str = None):
+def elog_report_post(summary_file: str, update_url: Optional[str] = None):
     """! Post a summary file to the eLog's run report section.
 
     @param summary_file (str) Path to the summary file to post.
-    @param update_url (str) URL to post to.
+    @param update_url (str | None) URL to post to. Attempts to retrieve if None.
     """
     with open(summary_file, 'r') as f:
         data: dict = json.load(f) # load for files instead of loads
         post_list: list = [ { 'key': f'{key}', 'value': f'{data[key]}' }
                             for key in data ]
-        requests.post(update_url, json = post_list)
+        if not update_url:
+            url = os.environ.get('JID_UPDATE_COUNTERS')
+            if url:
+                requests.post(url, json = post_list)
+        else:
+            requests.post(update_url, json = post_list)
+
 
 def update_summary(summary_file: str, data: dict):
     """! Append summary data to a JSON file.

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -30,8 +30,11 @@ def update_summary(summary_file: str, data: dict):
     @param summary_file (str) Path to the summary file to update.
     @param data (dict) Key/value pairs to be stored in the JSON summary.
     """
-    with open(summary_file, 'r+') as f:
-        summary_data: dict = json.load(f)
+    with open(summary_file, 'a+') as f:
+        try:
+            summary_data: dict = json.load(f)
+        except json.decoder.JSONDecodeError:
+            summary_data: dict = {}
         summary_data.update(data)
         json.dump(summary_data, f) # dump for files instead of dumps
 

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -2,6 +2,31 @@ import os
 import numpy as np
 import shutil
 from glob import glob
+import json
+import requests
+
+def elog_report_post(summary_file: str, update_url: str = None):
+    """! Post a summary file to the eLog's run report section.
+
+    @param summary_file (str) Path to the summary file to post.
+    @param update_url (str) URL to post to.
+    """
+    with open(summary_file, 'r') as f:
+        data: dict = json.load(f) # load for files instead of loads
+        post_list: list = [ { 'key': f'{key}', 'value': f'{data[key]}' }
+                            for key in data ]
+        requests.post(update_url, json = post_list)
+
+def update_summary(summary_file: str, data: dict):
+    """! Append summary data to a JSON file.
+
+    @param summary_file (str) Path to the summary file to update.
+    @param data (dict) Key/value pairs to be stored in the JSON summary.
+    """
+    with open(summary_file, 'r+') as f:
+        summary_data: dict = json.load(f)
+        summary_data.update(data)
+        json.dump(summary_data, f) # dump for files instead of dumps
 
 class eLogInterface:
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -94,7 +94,7 @@ class Indexer:
         print(f"Indexing executable written to {self.tmp_exe}")
 
     @property
-    def indexing_summary(self) -> dict:
+    def idx_summary(self) -> dict:
         """! Return a dictionary of key/values to post to the eLog.
 
         @return (dict) summary_dict Key/values parsed by eLog posting function.
@@ -206,4 +206,4 @@ if __name__ == '__main__':
         indexer_obj.report(params.update_url)
 
     summary_file = f'{params.taskdir[:-6]}/summary_r{params.run:04}.json'
-    update_summary(summary_file, indexer_obj.indexing_summary)
+    update_summary(summary_file, indexer_obj.idx_summary)

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -3,7 +3,6 @@ import os
 import requests
 import subprocess
 from btx.interfaces.ischeduler import *
-from btx.interfaces.ielog import update_summary
 
 class Indexer:
     
@@ -15,7 +14,7 @@ class Indexer:
     def __init__(self, exp, run, det_type, tag, taskdir, geom, cell=None, int_rad='4,5,6', methods='mosflm',
                  tolerance='5,5,5,1.5', tag_cxi=None, no_revalidate=True, multi=True, profile=True,
                  ncores=64, queue='milano', time='1:00:00'):
-        
+
         # experiment parameters
         self.exp = exp
         self.run = run
@@ -24,7 +23,7 @@ class Indexer:
         self.taskdir = taskdir
         self.tag = tag
         self.tag_cxi = tag_cxi
-        
+
         # indexing parameters
         self.geom = geom # geometry file in CrystFEL format
         self.cell = cell # file containing unit cell information
@@ -92,32 +91,6 @@ class Indexer:
         js.clean_up()
         js.submit()
         print(f"Indexing executable written to {self.tmp_exe}")
-
-    @property
-    def idx_summary(self) -> dict:
-        """! Return a dictionary of key/values to post to the eLog.
-
-        @return (dict) summary_dict Key/values parsed by eLog posting function.
-        """
-        # retrieve number of indexed patterns
-        command = ["grep", "Cell parameters", f"{self.stream}"]
-        output,error  = subprocess.Popen(
-            command, universal_newlines=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        n_indexed = len(output.split('\n')[:-1])
-            
-        # retrieve number of total patterns
-        command = ["grep", "Number of hits found", f"{self.peakfinding_summary}"]
-        output,error  = subprocess.Popen(
-            command, universal_newlines=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        n_total = int(output.split(":")[1].split("\n")[0])
-
-        key_strings: list = ['Number of lattices found',
-                             'Fractional indexing rate (including multiple lattices)']
-        summary_dict:dict = { key_strings[0] : f'{n_indexed}',
-                              key_strings[1] : f'{(n_indexed/n_total):.2f}' }
-        return summary_dict
 
     def report(self, update_url=None):
         """
@@ -203,7 +176,5 @@ if __name__ == '__main__':
     if not params.report:
         indexer_obj.launch()
     else:
-        indexer_obj.report(params.update_url)
-
-    summary_file = f'{params.taskdir[:-6]}/summary_r{params.run:04}.json'
-    update_summary(summary_file, indexer_obj.idx_summary)
+        pass
+        #indexer_obj.report(params.update_url)

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -3,6 +3,7 @@ import os
 import requests
 import subprocess
 from btx.interfaces.ischeduler import *
+from btx.interfaces.ielog import update_summary
 
 class Indexer:
     
@@ -91,7 +92,33 @@ class Indexer:
         js.clean_up()
         js.submit()
         print(f"Indexing executable written to {self.tmp_exe}")
+
+    @property
+    def indexing_summary(self) -> dict:
+        """! Return a dictionary of key/values to post to the eLog.
+
+        @return (dict) summary_dict Key/values parsed by eLog posting function.
+        """
+        # retrieve number of indexed patterns
+        command = ["grep", "Cell parameters", f"{self.stream}"]
+        output,error  = subprocess.Popen(
+            command, universal_newlines=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        n_indexed = len(output.split('\n')[:-1])
             
+        # retrieve number of total patterns
+        command = ["grep", "Number of hits found", f"{self.peakfinding_summary}"]
+        output,error  = subprocess.Popen(
+            command, universal_newlines=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        n_total = int(output.split(":")[1].split("\n")[0])
+
+        key_strings: list = ['Number of lattices found',
+                             'Fractional indexing rate (including multiple lattices)']
+        summary_dict:dict = { key_strings[0] : f'{n_indexed}',
+                              key_strings[1] : f'{(n_indexed/n_total):.2f}' }
+        return summary_dict
+
     def report(self, update_url=None):
         """
         Write results to a .summary file and optionally post to the elog.
@@ -177,3 +204,6 @@ if __name__ == '__main__':
         indexer_obj.launch()
     else:
         indexer_obj.report(params.update_url)
+
+    summary_file = f'{params.taskdir[:-6]}/summary_r{params.run:04}.json'
+    update_summary(summary_file, indexer_obj.indexing_summary)

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -391,6 +391,25 @@ class PeakFinder:
                                             { "key": "Number of hits found", "value": f"{self.n_hits_total}"},
                                             { "key": "Fractional hit rate", "value": f"{(self.n_hits_total/self.n_events_per_rank[-1]):.2f}"}, ])
 
+    @property
+    def pf_summary(self) -> dict:
+        """! Return a dictionary of key/values to post to the eLog.
+
+        @return (dict) summary_dict Key/values parsed by eLog posting function.
+        """
+        summary_dict = {}
+        if self.rank == 0:
+            key_strings: list = ['Number of events processed',
+                                 'Number of hits found',
+                                 'Fractional hit rate']
+            n_events_per_rank = self.n_events_per_rank[-1]
+            n_hits = self.n_hits_total
+            fractional = n_hits/n_events_per_rank
+            summary_dict.update({ key_strings[0] : f'{n_events_per_rank}',
+                                  key_strings[1] : f'{n_hits}',
+                                  key_strings[2] : f'{fractional:.2f}'})
+        return summary_dict
+
     def compute_powders(self, fnames):
         """
         Compute the powder hits and misses by iterating through valid files.

--- a/btx/processing/peak_finder.py
+++ b/btx/processing/peak_finder.py
@@ -7,6 +7,7 @@ from mpi4py import MPI
 from btx.interfaces.ipsana import *
 from psalgos.pypsalgos import PyAlgos
 import matplotlib.pyplot as plt
+import sys
 
 class PeakFinder:
     

--- a/dags/index_run.py
+++ b/dags/index_run.py
@@ -22,5 +22,9 @@ find_peaks = JIDSlurmOperator( task_id=task_id, dag=dag)
 task_id='index'
 index = JIDSlurmOperator( task_id=task_id, dag=dag)
 
+task_id='post_to_elog'
+elog1 = JIDSlurmOperator(task_id = task_id, dag=dag)
+elog2 = JIDSlurmOperator(task_id = task_id, dag=dag)
+
 # Draw the DAG
-find_peaks >> index
+find_peaks >> elog1 >> index >> elog2

--- a/dags/index_run.py
+++ b/dags/index_run.py
@@ -17,14 +17,17 @@ dag = DAG(
 
 # Tasks SETUP
 task_id='find_peaks'
-find_peaks = JIDSlurmOperator( task_id=task_id, dag=dag)
-
-task_id='index'
-index = JIDSlurmOperator( task_id=task_id, dag=dag)
+find_peaks = JIDSlurmOperator(task_id=task_id, dag=dag)
 
 task_id='post_to_elog'
 elog1 = JIDSlurmOperator(task_id = task_id, dag=dag)
-elog2 = JIDSlurmOperator(task_id = task_id, dag=dag)
+
+task_id='index'
+index = JIDSlurmOperator(task_id=task_id, dag=dag)
+
+task_id='summarize_idx'
+elog2 = JIDSlurmOperator(task_id=task_id, dag=dag)
+
 
 # Draw the DAG
 find_peaks >> elog1 >> index >> elog2

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -159,6 +159,7 @@ def opt_geom(config):
 def find_peaks(config):
     from btx.processing.peak_finder import PeakFinder
     from btx.misc.shortcuts import fetch_latest
+    from btx.interfaces.ielog import update_summary
     setup = config.setup
     task = config.find_peaks
     """ Perform adaptive peak finding on run. """
@@ -181,6 +182,9 @@ def find_peaks(config):
         logger.debug("Could not communicate with the elog update url")
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
+
+    summary_file = f'{setup.root_dir}/summary_r{setup.run:04}.json'
+    update_summary(summary_file, pf.pf_summary)
 
 def index(config):
     from btx.processing.indexer import Indexer
@@ -347,6 +351,17 @@ def elog_display(config):
     eli = eLogInterface(setup)
     eli.update_summary()
     logger.debug('Done!')
+
+def post_to_elog(config):
+    from btx.interfaces.ielog import elog_report_post
+    setup = config.setup
+    root_dir = setup.root_dir
+    run = setup.run
+
+    summary_file = f'{root_dir}/summary_r{run:04}.json'
+    url = os.environ.get('JID_UPDATE_COUNTERS')
+    if url:
+        elog_report_post(summary_file, url)
 
 def visualize_sample(config):
     from btx.misc.visuals import VisualizeSample

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -183,8 +183,9 @@ def find_peaks(config):
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
 
-    summary_file = f'{setup.root_dir}/summary_r{setup.run:04}.json'
-    update_summary(summary_file, pf.pf_summary)
+    if pf.rank == 0:
+        summary_file = f'{setup.root_dir}/summary_r{setup.run:04}.json'
+        update_summary(summary_file, pf.pf_summary)
 
 def index(config):
     from btx.processing.indexer import Indexer


### PR DESCRIPTION
Currently, each task posts a new dictionary to the eLog report section. This overwrites previous tasks' information (except between `find_peaks` and `index` which is handled in an ad hoc way). The changes below maintain a single JSON file to which each task appends information upon completion. In this way, no information is lost, and the same task can be run multiple times to compare results in a single location. The file is named for the run it corresponds to, and is maintained in the `root_dir`. A separate task then posts the file to the eLog.

Change log
----------------
- Functions `btx.interfaces.ielog.update_summary` and `btx.interfaces.ielog.elog_report_post` to handle updating and posting a single file to the eLog's report section on a run-by-run basis. This should prevent overwriting as new tasks update the summary.
- Property in `peak_finder` to return the appropriate summary information in dictionary form. This is used by `update_summary` in the `find_peaks` task to append to the single JSON file with summary information.
- New task `summarize_idx` which summarizes the indexing results. This task was separated from the indexing task, unlike with `find_peaks`, due to unresolved issues with mpirun which will be returned to later.
- Changes to the `index_run` DAG to incorporate the new task for posting to the eLog.