### PR TITLE
Patch json

### DIFF
--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -35,12 +35,13 @@ def update_summary(summary_file: str, data: dict):
     @param summary_file (str) Path to the summary file to update.
     @param data (dict) Key/value pairs to be stored in the JSON summary.
     """
-    with open(summary_file, 'a+') as f:
+    with open(summary_file, 'r+') as f:
         try:
             summary_data: dict = json.load(f)
         except json.decoder.JSONDecodeError:
             summary_data: dict = {}
         summary_data.update(data)
+        f.seek(0)
         json.dump(summary_data, f) # dump for files instead of dumps
 
 class eLogInterface:

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -35,14 +35,15 @@ def update_summary(summary_file: str, data: dict):
     @param summary_file (str) Path to the summary file to update.
     @param data (dict) Key/value pairs to be stored in the JSON summary.
     """
-    with open(summary_file, 'a+') as f:
-        f.seek(0)
+    with open(summary_file, 'r+') as f:
         try:
             summary_data: dict = json.load(f)
         except json.decoder.JSONDecodeError:
             summary_data: dict = {}
-        summary_data.update(data)
-        f.seek(0)
+
+    summary_data.update(data)
+
+    with open(summary_file, 'w') as f:
         json.dump(summary_data, f) # dump for files instead of dumps
 
 class eLogInterface:

--- a/btx/interfaces/ielog.py
+++ b/btx/interfaces/ielog.py
@@ -35,7 +35,8 @@ def update_summary(summary_file: str, data: dict):
     @param summary_file (str) Path to the summary file to update.
     @param data (dict) Key/value pairs to be stored in the JSON summary.
     """
-    with open(summary_file, 'r+') as f:
+    with open(summary_file, 'a+') as f:
+        f.seek(0)
         try:
             summary_data: dict = json.load(f)
         except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Change log
----------------
- Changes to `interfaces.ielog.update_summary`
- Move file pointer back to beginning of file at beginning and after updating dictionary to fully update the json file.
- This should allow the elog reporting and subsequent readings of the file to proceed without issue since there will be only a single dictionary (i.e. it will be proper json file).