### PR TITLE
Fix eLog reporting (Third time's the charm)

### DIFF
--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -125,9 +125,6 @@ class JobScheduler:
             if 'SIT_PSDM_DATA' in os.environ:
                 jfile.write(f"export SIT_PSDM_DATA={os.environ['SIT_PSDM_DATA']}\n")
 
-        # debugging
-        with open(self.jobfile, 'a') as jfile:
-            jfile.write('export PYTHONPATH="${PYTHONPATH}:/sdf/home/f/fpoitevi/sw/btx/scripts/"')
 
     def write_main(self, application, dependencies=[]):
         """ Write application and source requested dependencies. """

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -1,7 +1,10 @@
 import shutil
+import logging
 import os
 
 """ Helper methods for job scheduling. """
+
+logger = logging.getLogger(__name__)
 
 class JobScheduler:
 
@@ -134,7 +137,7 @@ class JobScheduler:
     def submit(self):
         """ Submit to queue. """
         os.system(f"sbatch {self.jobfile}")
-        print(f"sbatch {self.jobfile}")
+        logger.info(f"sbatch {self.jobfile}")
 
     def clean_up(self):
         """ Add a line to delete submission file."""

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -125,7 +125,6 @@ class JobScheduler:
             if 'SIT_PSDM_DATA' in os.environ:
                 jfile.write(f"export SIT_PSDM_DATA={os.environ['SIT_PSDM_DATA']}\n")
 
-
     def write_main(self, application, dependencies=[]):
         """ Write application and source requested dependencies. """
         if dependencies:

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -91,6 +91,9 @@ class JobScheduler:
             with open(self.jobfile, 'a') as jfile:
                 jfile.write(f"#SBATCH -A {self.account}\n\n")
 
+        with open(self.jobfile, 'w') as jfile:
+            jfile.write("module load mpi/mpich\n")
+
     def _write_dependencies(self, dependencies):
         """ Source dependencies."""
         dep_paths = ""

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -55,8 +55,8 @@ class JobScheduler:
         for ppath in possible_paths:
             if os.path.exists(ppath):
                 pythonpath = ppath
-                #if self.ncores > 1:
-                #    pythonpath = f"{os.path.split(ppath)[0]}/mpirun -n {self.ncores} {ppath}"
+                if self.ncores > 1:
+                    pythonpath = f"{os.path.split(ppath)[0]}/mpirun -n {self.ncores} {ppath}"
 
         return pythonpath            
 

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -55,8 +55,8 @@ class JobScheduler:
         for ppath in possible_paths:
             if os.path.exists(ppath):
                 pythonpath = ppath
-                if self.ncores > 1:
-                    pythonpath = f"{os.path.split(ppath)[0]}/mpirun -n {self.ncores} {ppath}"
+                #if self.ncores > 1:
+                #    pythonpath = f"{os.path.split(ppath)[0]}/mpirun -n {self.ncores} {ppath}"
 
         return pythonpath            
 

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -91,7 +91,7 @@ class JobScheduler:
             with open(self.jobfile, 'a') as jfile:
                 jfile.write(f"#SBATCH -A {self.account}\n\n")
 
-        with open(self.jobfile, 'w') as jfile:
+        with open(self.jobfile, 'a') as jfile:
             jfile.write("module load mpi/mpich\n")
 
     def _write_dependencies(self, dependencies):

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -91,9 +91,6 @@ class JobScheduler:
             with open(self.jobfile, 'a') as jfile:
                 jfile.write(f"#SBATCH -A {self.account}\n\n")
 
-        with open(self.jobfile, 'a') as jfile:
-            jfile.write("module load mpi/mpich\n")
-
     def _write_dependencies(self, dependencies):
         """ Source dependencies."""
         dep_paths = ""
@@ -127,6 +124,10 @@ class JobScheduler:
             jfile.write(dep_paths)
             if 'SIT_PSDM_DATA' in os.environ:
                 jfile.write(f"export SIT_PSDM_DATA={os.environ['SIT_PSDM_DATA']}\n")
+
+        # debugging
+        with open(self.jobfile, 'a') as jfile:
+            jfile.write('export PYTHONPATH="${PYTHONPATH}:/sdf/home/f/fpoitevi/sw/btx/scripts/"')
 
     def write_main(self, application, dependencies=[]):
         """ Write application and source requested dependencies. """

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -1,10 +1,13 @@
 import argparse
+import logging
 import os
 import requests
 import subprocess
 from btx.interfaces.ischeduler import *
 from btx.interfaces.ielog import update_summary, elog_report_post
 from mpi4py import MPI
+
+logger = logging.getLogger(__name__)
 
 class Indexer:
     
@@ -95,7 +98,7 @@ class Indexer:
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         js.clean_up()
         js.submit()
-        print(f"Indexing executable written to {self.tmp_exe}")
+        logger.info(f"Indexing executable written to {self.tmp_exe}")
 
     @property
     def idx_summary(self) -> dict:

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -99,9 +99,7 @@ class Indexer:
 
         js = JobScheduler(self.tmp_exe, ncores=self.ncores, jobname=f'idx_r{self.run:04}', queue=self.queue, time=self.time)
         js.write_header()
-        # debugging
-        js.write_main(command, dependencies=['psana'] + self.methods.split(','))
-        #js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
+        js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         # debugging
         #js.clean_up()
         js.submit()

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -85,11 +85,13 @@ class Indexer:
         if self.no_revalidate: command += ' --no-revalidate'
         if self.multi: command += ' --multi'
         if self.profile: command += ' --profile'
+        # debugging
+        command="module load mpi/mpich"
 
         if not dont_report:
             #command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             # debugging
-            command =f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
+            command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             if ( self.tag_cxi != '' ): command += f' --tag_cxi {self.tag_cxi}'
             command += "\n"
         if addl_command is not None:

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -87,7 +87,9 @@ class Indexer:
         if self.profile: command += ' --profile'
 
         if not dont_report:
-            command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
+            #command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
+            # debugging
+            command =f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             if ( self.tag_cxi != '' ): command += f' --tag_cxi {self.tag_cxi}'
             command += "\n"
         if addl_command is not None:

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -92,6 +92,8 @@ class Indexer:
             command =f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             if ( self.tag_cxi != '' ): command += f' --tag_cxi {self.tag_cxi}'
             command += "\n"
+            # debugging
+            command =f"\npython /sdf/data/lcls/ds/mfx/mfxp23120/scratch/fpoitevi/launchpad/test2.py"
         if addl_command is not None:
             command += f"\n{addl_command}"
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -99,7 +99,9 @@ class Indexer:
 
         js = JobScheduler(self.tmp_exe, ncores=self.ncores, jobname=f'idx_r{self.run:04}', queue=self.queue, time=self.time)
         js.write_header()
-        js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
+        # debugging
+        js.write_main(command, dependencies=['psana'] + self.methods.split(','))
+        #js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         # debugging
         #js.clean_up()
         js.submit()

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -85,13 +85,11 @@ class Indexer:
         if self.no_revalidate: command += ' --no-revalidate'
         if self.multi: command += ' --multi'
         if self.profile: command += ' --profile'
-        # debugging
-        command="module load mpi/mpich"
 
         if not dont_report:
             #command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             # debugging
-            command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
+            command =f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             if ( self.tag_cxi != '' ): command += f' --tag_cxi {self.tag_cxi}'
             command += "\n"
         if addl_command is not None:

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -87,21 +87,16 @@ class Indexer:
         if self.profile: command += ' --profile'
 
         if not dont_report:
-            #command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
-            # debugging
-            command =f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
+            command +=f"\npython {self.script_path} -e {self.exp} -r {self.run} -d {self.det_type} --taskdir {self.taskdir} --report --tag {self.tag} "
             if ( self.tag_cxi != '' ): command += f' --tag_cxi {self.tag_cxi}'
             command += "\n"
-            # debugging
-            command =f"\npython /sdf/data/lcls/ds/mfx/mfxp23120/scratch/fpoitevi/launchpad/test2.py"
         if addl_command is not None:
             command += f"\n{addl_command}"
 
         js = JobScheduler(self.tmp_exe, ncores=self.ncores, jobname=f'idx_r{self.run:04}', queue=self.queue, time=self.time)
         js.write_header()
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
-        # debugging
-        #js.clean_up()
+        js.clean_up()
         js.submit()
         logger.info(f"Indexing executable submitted: {self.tmp_exe}")
 
@@ -206,8 +201,7 @@ def parse_input():
 if __name__ == '__main__':
     
     params = parse_input()
-
-    logger.info("Instantiating indexer object.")
+    
     indexer_obj = Indexer(exp=params.exp, run=params.run, det_type=params.det_type, tag=params.tag, taskdir=params.taskdir, geom=params.geom, 
                           cell=params.cell, int_rad=params.int_rad, methods=params.methods, tolerance=params.tolerance, tag_cxi=params.tag_cxi,
                           no_revalidate=params.no_revalidate, multi=params.multi, profile=params.profile, ncores=params.ncores, queue=params.queue,

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -98,7 +98,8 @@ class Indexer:
         js = JobScheduler(self.tmp_exe, ncores=self.ncores, jobname=f'idx_r{self.run:04}', queue=self.queue, time=self.time)
         js.write_header()
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
-        js.clean_up()
+        # debugging
+        #js.clean_up()
         js.submit()
         logger.info(f"Indexing executable submitted: {self.tmp_exe}")
 

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -204,7 +204,8 @@ def parse_input():
 if __name__ == '__main__':
     
     params = parse_input()
-    
+
+    logger.info("Instantiating indexer object.")
     indexer_obj = Indexer(exp=params.exp, run=params.run, det_type=params.det_type, tag=params.tag, taskdir=params.taskdir, geom=params.geom, 
                           cell=params.cell, int_rad=params.int_rad, methods=params.methods, tolerance=params.tolerance, tag_cxi=params.tag_cxi,
                           no_revalidate=params.no_revalidate, multi=params.multi, profile=params.profile, ncores=params.ncores, queue=params.queue,

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -98,7 +98,7 @@ class Indexer:
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         js.clean_up()
         js.submit()
-        logger.info(f"Indexing executable written to {self.tmp_exe}")
+        logger.info(f"Indexing executable submitted: {self.tmp_exe}")
 
     @property
     def idx_summary(self) -> dict:
@@ -207,8 +207,10 @@ if __name__ == '__main__':
                           no_revalidate=params.no_revalidate, multi=params.multi, profile=params.profile, ncores=params.ncores, queue=params.queue,
                           time=params.time)
     if not params.report:
+        logger.info("Launching indexing...")
         indexer_obj.launch()
     else:
+        logger.info("Indexing report on the way...")
         if indexer_obj.rank == 0:
             summary_file = f'{params.taskdir[:-6]}/summary_r{params.run:04}.json'
             update_summary(summary_file, indexer_obj.idx_summary)

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -220,5 +220,3 @@ if __name__ == '__main__':
             summary_file = f'{params.taskdir[:-6]}/summary_r{params.run:04}.json'
             update_summary(summary_file, indexer_obj.idx_summary)
             elog_report_post(summary_file)
-        #pass
-        #indexer_obj.report(params.update_url)

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -193,7 +193,7 @@ if [ ${RUN_NUM} != 'None' ]; then
 fi
 
 echo "$MAIN_PY -c ${THIS_CONFIGFILE} -t $TASK"
-$MAIN_PY -c ${THIS_CONFIGFILE} -t $TASK
+$MAIN_PY -c ${THIS_CONFIGFILE} -t $TASK -n $CORES
 if [ ${RUN_NUM} != 'None' ]; then
   rm -f ${THIS_CONFIGFILE}
 fi

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -198,7 +198,7 @@ def index(config):
     indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, tag=task.tag, tag_cxi=task.get('tag_cxi'), taskdir=taskdir,
                           geom=geom_file, cell=task.get('cell'), int_rad=task.int_radius, methods=task.methods, tolerance=task.tolerance, no_revalidate=task.no_revalidate,
                           multi=task.multi, profile=task.profile, queue=setup.get('queue'), ncores=task.get('ncores') if task.get('ncores') is not None else 64,
-                          time=task.get('time') if task.get('time') is not None else '1:00:00')
+                          time=task.get('time') if task.get('time') is not None else '1:00:00', mpi_init = False)
     logger.debug(f'Generating indexing executable for run {setup.run} of {setup.exp}...')
     indexer_obj.launch()
     logger.info(f'Indexing launched!')

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -176,10 +176,6 @@ def find_peaks(config):
     pf.find_peaks()
     pf.curate_cxi()
     pf.summarize()
-    #try:
-    #    pf.report(update_url)
-    #except:
-    #    logger.debug("Could not communicate with the elog update url")
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
 

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -176,10 +176,10 @@ def find_peaks(config):
     pf.find_peaks()
     pf.curate_cxi()
     pf.summarize()
-    try:
-        pf.report(update_url)
-    except:
-        logger.debug("Could not communicate with the elog update url")
+    #try:
+    #    pf.report(update_url)
+    #except:
+    #    logger.debug("Could not communicate with the elog update url")
     logger.info(f'Saving CXI files and summary to {taskdir}/r{setup.run:04}')
     logger.debug('Done!')
 


### PR DESCRIPTION
Change log
----------------
- Fix `FileNotFoundError` when writing the unified summary json file.
- Remove the old-style reporting function from `find_peaks`.
- Return the responsibility of reporting to the elog to the `index` task and not a secondary task. This will avoid the issues with the report task being called to early due to the difficulties of two-stage batch submission and airflow's task management.
- In line with the current multi-task setup, `indexer` only updates the summary file on rank 0. It will also post to the elog only on that rank.
- Patch `mpirun` problems through conditional import (and therefore initialization) of MPI in `main` and `indexer`. This requires:
  - The passing of an additional command-line argument to `main` via `elog_submit` (`-n $CORES`)
  - Conditional import in `main` based on number of cores.
  - An additional parameter `mpi_init` in `indexer` which determines whether to import MPI or not.
    - MPI is not imported in the first job - set `mpi_init = False` in task definition 
    - Set `mpi_init = True` when `indexer.py` is run directly (in the `if __name__ == '__main__'` block).

TODO (In two upcoming PRs)
--------
- Fix `mpirun` for other tasks which have problems when using the `ischeduler` two-step submission.
- Update all DAGs (/Tasks) to make use of the shared json summary file for elog reporting.