### PR TITLE
Updated eLog Reporting and Airflow Management for `process_sfx` Tasks

### DIFF
--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -137,7 +137,7 @@ class JobScheduler:
     def submit(self):
         """ Submit to queue. """
         os.system(f"sbatch {self.jobfile}")
-        logger.info(f"sbatch {self.jobfile}")
+        logger.info(f"sbatch -W {self.jobfile}")
 
     def clean_up(self):
         """ Add a line to delete submission file."""

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -136,7 +136,7 @@ class JobScheduler:
 
     def submit(self):
         """ Submit to queue. """
-        os.system(f"sbatch {self.jobfile}")
+        os.system(f"sbatch -W {self.jobfile}")
         logger.info(f"sbatch -W {self.jobfile}")
 
     def clean_up(self):

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -681,12 +681,11 @@ if __name__ == '__main__':
         if not params.cell_only:
             st.plot_peakogram(output=os.path.join(params.outdir, f"{params.tag}_peakogram.png"))
 
-        run = get_most_recent_run(streams)
+        run: int = get_most_recent_run(streams)
         indexdir: str = stream_path[:-len(stream_path.split('/')[-1])]
         rootdir: str = indexdir[:-7]
         summary_file: str = f'{rootdir}/summary_r{run:04}.json'
         update_summary(summary_file, st.stream_summary)
         elog_report_post(summary_file)
-        #st.report(tag=params.tag)
         if params.cell_out is not None:
             write_cell_file(st.cell_params, params.cell_out, input_file=params.cell_ref)

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -107,6 +107,7 @@ class Indexer:
     @property
     def idx_summary(self) -> dict:
         """! Return a dictionary of key/values to post to the eLog.
+
         @return (dict) summary_dict Key/values parsed by eLog posting function.
         """
         # retrieve number of indexed patterns

--- a/dags/index_run.py
+++ b/dags/index_run.py
@@ -25,9 +25,5 @@ elog1 = JIDSlurmOperator(task_id = task_id, dag=dag)
 task_id='index'
 index = JIDSlurmOperator(task_id=task_id, dag=dag)
 
-task_id='summarize_idx'
-elog2 = JIDSlurmOperator(task_id=task_id, dag=dag)
-
-
 # Draw the DAG
-find_peaks >> elog1 >> index >> elog2
+find_peaks >> elog1 >> index

--- a/dags/process_sfx.py
+++ b/dags/process_sfx.py
@@ -19,6 +19,9 @@ dag = DAG(
 task_id='find_peaks'
 find_peaks = JIDSlurmOperator( task_id=task_id, dag=dag)
 
+task_id='post_to_elog'
+elog1 = JIDSlurmOperator(task_id=task_id, dag=dag)
+
 task_id='index'
 index = JIDSlurmOperator( task_id=task_id, dag=dag)
 
@@ -35,4 +38,4 @@ task_id='elog_display'
 elog_display = JIDSlurmOperator(task_id=task_id, dag=dag)
 
 # Draw the DAG
-find_peaks >> index >> stream_analysis >> merge >> solve >> elog_display
+find_peaks >> elog1 >> index >> stream_analysis >> merge >> solve >> elog_display

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -129,7 +129,6 @@ QUEUE=${QUEUE:='milano'}
 CORES=${CORES:=1}
 # TODO: find_peaks needs to be handled from ischeduler. For now we do this...
 if [ ${TASK} != 'find_peaks' ] &&\
-   [ ${TASK} != 'stream_analysis' ] &&\
    [ ${TASK} != 'determine_cell' ] &&\
    [ ${TASK} != 'opt_geom' ]; then
   CORES=1


### PR DESCRIPTION
Change Log
-----------------
- [x] Have all tasks within the `process_sfx` DAG use the unified summary JSON file for eLog reporting.
  - [x] Updated `stream_analysis` to the single JSON.
  - [x] Updated `merge` to the single JSON.
  - `find_peaks` and `index` were already using it from previous PR.
  - Since `solve` was not previously reporting anything to the eLog it has not been updated. `elog_display` likewise has not been updated.
- [x] Remove unnecessary task from `index_run` DAG.
- [x] Fix multi-core bug (related to the other MPI issues) in `stream_analysis` for running from eLog.
- [x] `stream_analysis` only updates the eLog summary for the most recent run with the specified tag. Therefore the report for each run contains the indexing results for that run, as well as the total indexing results for all runs up to that point with the same tag.
- [x] Have first round jobs wait for `JobScheduler` jobs to finish to help with Airflow task processing/scheduling.
- [x] Warning arising during plotting in `merge` is suppressed by setting xticks values before the labels.
- [x] Fix apparent error in JSON handling during `merge` by only attempting read/write of summary file on rank 0.

Limitations
----------------
- **One core is sacrificial when using `JobScheduler`**. In order for Airflow to not prematurely advance to the next task, the job it initially submitted must continue running.
  - It is only one core, but this should be the highest priority thing to fix!
- Tasks run out of order may select the wrong summary file. Tasks such as `stream_analysis` or `merge` must be run as later tasks in a DAG or they are likely to select the wrong file.
- There can be issues if the summary file is moved or deleted before the tasks finish. Or if there is no summary file before later tasks (such as `merge`) are called.
- Functions created to help in `stream_analysis` and `merge` are non-general. Specifically, `get_most_recent_run` and `get_most_recent_summary` should be improved and moved to somewhere else in a refactor. They accomplish almost the exact same functionality but in a non-graceful and non-general way.

Future
----------
- Noticed an error in the `index` task related to the reading of HDF5 files. This doesn't cause the task to fail but should be investigated to make sure that there aren't underlying issues related to data handling.
 ```
HDF5-DIAG: Error detected in HDF5 (1.12.1) thread 0:
  #000: H5Dio.c line 179 in H5Dread(): can't read data
```