### PR TITLE
[Bug Fix] `merge` task doesn't copy `mtz`

### DIFF
--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -378,3 +378,15 @@ if __name__ == '__main__':
             )
             update_summary(summary_file, summary_dict)
             elog_report_post(summary_file)
+
+            if stream_to_mtz.mtz_dir:
+                shutil.copyfile(
+                    os.path.join(
+                        stream_to_mtz.taskdir,
+                        f'{stream_to_mtz.prefix}.mtz'
+                    ),
+                    os.path.join(
+                        stream_to_mtz.mtz_dir,
+                        f'{stream_to_mtz.prefix}.mtz'
+                    )
+                )


### PR DESCRIPTION
Change Log
-----------------
- Copy `mtz` file from the `merge` folder to `solve` folder.
  - This was the previous behavior but was unintentionally removed when I updated the `merge` task to use the unified summary json file.