### PR TITLE
ENH: Provide setup scripts and a default config YAML

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,77 @@
+setup:
+  queue: 'milano'
+  root_dir: ''
+  exp: ''
+  run: 5
+  det_type: 'epix10k2M'
+  cell: ''
+
+elog_display:
+
+fetch_mask:
+  dataset: '/data/data'
+
+fetch_geom:
+
+build_mask:
+  thresholds: -10 5000
+  n_images: 20
+  n_edge: 1
+  combine: True
+
+run_analysis:
+  max_events: -1
+  ncores: 2
+
+opt_geom:
+  dx: -6 6 5
+  dy: -6 6 5
+  n_iterations: 5
+  n_peaks: 4
+  threshold: 1000000
+
+find_peaks:
+  tag: ''
+  psana_mask: False
+  min_peaks: 10
+  max_peaks: 2048
+  npix_min: 2
+  npix_max: 30
+  amax_thr: 40.
+  atot_thr: 180.
+  son_min: 10.0
+  peak_rank: 3
+  r0: 3.0
+  dr: 2.0
+  nsigm: 10.0
+
+index:
+  time: '1:30:00'
+  ncores: 64
+  tag: ''
+  tag_cxi: ''
+  int_radius: '3,4,5'
+  methods: 'mosflm'
+  tolerance: '5,5,5,1.5'
+  no_revalidate: True
+  multi: True
+  profile: True
+  cell: ''
+
+stream_analysis:
+  tag: ''
+  cell_only: False
+  ncores: 6
+
+merge:
+  tag: ''
+  symmetry: '4/mmm_uac'
+  iterations: 1
+  model: 'unity'
+  foms: 'CCstar Rsplit'
+  nshells: 10
+  highres: 2.5
+
+solve:
+  tag: ''
+  pdb: ''

--- a/scripts/setup_btx.py
+++ b/scripts/setup_btx.py
@@ -1,0 +1,161 @@
+"""Prepare eLog jobs for btx workflows.
+
+Functions
+---------
+determine_configuration(args, workflow)
+    Parse provided arguments and return a formatted command for job submission.
+"""
+import os
+import argparse
+import requests
+import json
+import logging
+import re
+from typing import List, Dict, Tuple, Any, Optional
+
+from krtc import KerberosTicket
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def determine_configuration(
+        args: argparse.Namespace,
+        workflow: Optional[str] = None
+) -> Optional[Tuple[str, str, str]]:
+    """Parse arguments and format btx job submission command.
+
+    @param args (argparse.Namespace) Arguments parsed by argparse.Parser.
+    @param workflow (str | None) If provided, override the workflow provided
+        by a command-line argument.
+    @returns executable,param_string (str, str) The btx executable and the
+        formatted parameter string.
+    """
+    if not args.experiment:
+        logger.info("No experiment provided and cannot find one! ABORTING!")
+        return
+
+    exp: str = args.experiment
+    dag: str = ""
+    if workflow:
+        dag = workflow
+    else:
+        if args.workflow == "sfx":
+            dag = "process_sfx"
+        elif args.workflow == "geometry" or args.workflow == "behenate":
+            dag = "optimize_geometry"
+
+    btx_base_dir: str = "/sdf/group/lcls/ds/tools/btx/scripts"
+    btx_executable: str = "elog_trigger.py"
+    executable: str = f"{btx_base_dir}/{btx_executable}"
+
+    exp_dir: str = f"/sdf/data/lcls/ds/{exp[:3]}/{exp}"
+    config_file: str = f"{exp_dir}/scratch/btx/yamls/config.yaml"
+    param_string: str = (
+        f"-a {args.account} -c {config_file} -d {dag} -n {args.ncores}"
+        f"-q {args.queue}"
+    )
+
+    reservation: str = args.reservation
+    if reservation:
+        param_string += f"-r {reservation}"
+
+    if args.verbose:
+        param_string += f"--verbose"
+    return exp, executable, param_string
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-a",
+        "--account",
+        type=str,
+        help="Account to use for batch jobs. Defaults to lcls:$EXP",
+        default=f"lcls:{os.environ.get('EXPERIMENT', '')}"
+    )
+    parser.add_argument(
+        "-e",
+        "--experiment",
+        type=str,
+        help="Experiment to perform btx setup for.",
+        default=os.environ.get("EXPERIMENT", "")
+    )
+    parser.add_argument(
+        "-n",
+        "--ncores",
+        type=int,
+        help="Number of cores to use for jobs. Defaults to 64.",
+        default=64
+    )
+    parser.add_argument(
+        "-q",
+        "--queue",
+        type=str,
+        help="Queue to run on. Defaults to milano.",
+        default="milano"
+    )
+    parser.add_argument(
+        "-r",
+        "--reservation",
+        type=str,
+        help="Reservation if there is one. Defaults to None.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        type=str,
+        action="store_true",
+        help="Turn on verbose logging."
+    )
+    parser.add_argument(
+        "-w",
+        "--workflow",
+        type=str,
+        help=(
+            "Which analysis workflow to run. Defaults to sfx. Options: sfx, "
+            "geometry"
+        ),
+        default="sfx"
+    )
+    args = parser.parse_args()
+    res = determine_configuration(args)
+    workflows: List[Dict[str, str]] = []
+    if res:
+        exp, executable, params = res
+        main_workflow: Dict[str, str] = {
+            "name": "run_btx",
+            "executable": executable,
+            "trigger": "START_OF_RUN",
+            "location": "S3DF",
+            "parameters": params
+        }
+        workflows.append(main_workflow)
+        if "optimize_geometry" not in main_workflow["parameters"]:
+            geom_params: str = re.sub(
+                "-d.*-n",
+                "-d optimize_geometry -n",
+                params
+            )
+            geometry_workflow: Dict[str, str] = {
+                "name": "optimize_geometry",
+                "executable": executable,
+                "trigger": "MANUAL",
+                "location": "S3DF",
+                "parameters": geom_params
+            }
+            workflows.append(geometry_workflow)
+
+        for workflow in workflows:
+            krbticket: Any = KerberosTicket("HTTP@pswww.slac.stanford.edu")
+            krbheaders: dict = krbticket.getAuthHeaders()
+            url: str = (
+                f"https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk/{exp}/ws"
+                "/create_update_workflow_def"
+            )
+            post_params: Dict[str, Any] = {
+                "url": url,
+                "headers": krbheaders,
+                "json": workflow,
+            }
+            resp: requests.models.Response = requests.post(**post_params)
+            resp.raise_for_status()
+            # Extra logging and such...

--- a/scripts/setup_btx.sh
+++ b/scripts/setup_btx.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+usage()
+{
+cat << EOF
+$(basename "$0"):
+    Script to prepare btx directories and eLog jobs for an experiment.
+    OPTIONS:
+      -a | --account
+         Optionally specify an account to run with.
+      -e | --experiment
+         Experiment to setup btx for.
+      -h | --help
+         Display this help message.
+      -n | --ncores
+         Number of cores to use for btx jobs.
+      -q | --queue
+         Which S3DF queue to run on.
+      -r | --reservation
+         Optionally specifiy a reservation to run on.
+      -v | --verbose
+         Optionally enable verbose logging.
+      -w | --workflow
+         Specify which workflow to setup.
+EOF
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]
+do
+    arg="$1"
+
+    case $arg in
+        -a|--account)
+            ACCOUNT="$2"
+            shift
+            shift
+            ;;
+        -e|--experiment)
+            EXP="$2"
+            shift
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit
+            ;;
+        -n|--ncores)
+            CORES="$2"
+            shift
+            shift
+            ;;
+        -q|--queue)
+            QUEUE="$2"
+            shift
+            shift
+            ;;
+        -r|--reservation)
+            RESERVATION="$2"
+            shift
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            shift
+            ;;
+        -w|--workflow)
+            WORKFLOW="$2"
+            shift
+            shift
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            shift
+            ;;
+    esac
+done
+set -- "${ARGS[@]}"
+
+if [[ -z ${EXP} ]]; then
+    echo "You must provide an experiment name!"
+    usage
+    exit 1
+fi
+if [[ -z ${QUEUE} ]]; then
+    echo "No queue provided, defaulting to milano. Can abort with ctrl-c."
+    sleep 0.5
+fi
+if [[ -z ${CORES} ]]; then
+    echo "Number of cores not provided. Will use 64."
+fi
+if [[ -z ${WORKFLOW} ]]; then
+    echo "No workflow provided. Defaulting to SFX experiment."
+fi
+
+ACCOUNT=${ACCOUNT:="lcls"}
+CORES=${CORES:=64}
+QUEUE=${QUEUE:="milano"}
+WORKFLOW=${WORKFLOW:="sfx"}
+
+BTX_DIR="/sdf/group/lcls/ds/tools/btx"
+EXP_DIR="/sdf/data/lcls/ds/${EXP:0:3}/${EXP}"
+
+if [ ! -d "${EXP_DIR}" ]; then
+    echo "Experiment foldr does not exist yet."
+    exit 1
+fi
+
+
+umask 002
+echo "Preparing btx work directories."
+mkdir -p ${EXP_DIR}/scratch/btx/yamls
+mkdir -p ${EXP_DIR}/scratch/btx/launchpad
+cp ${BTX_DIR}/config/config.yaml ${EXP_DIR}/scratch/btx/yamls
+
+chmod -R o+r ${EXP_DIR}/scratch/btx
+chmod -R o+w ${EXP_DIR}/scratch/btx
+
+echo "Preparing eLog jobs."
+source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh
+PARAMS="-a ${ACCOUNT} -e ${EXP} -n ${CORES} -q ${QUEUE} -w ${WORKFLOW}"
+
+if [[ $RESERVATION ]]; then
+    PARAMS+=" -r ${RESERVATION}"
+fi
+if [[ $VERBOSE ]]; then
+    PARAMS+=" --verbose"
+fi
+
+python ${BTX_DIR}/scripts/setup_btx.py $PARAMS
+
+echo "Finished setup"


### PR DESCRIPTION
Change Log
-----------------
- Provide `setup_btx.sh` which creates a `btx` working directory in the experiment scratch folder and calls the eLog setup script.
- Provide `setup_btx.py` which creates workflow definitions in the eLog for an experiment.
- Include a default YAML file which is copied to the experiment scratch folder when running the setup bash script.

Testing
-----------
- TBD - still untested