### PR TITLE
Modified __new_config_path__ in JID to get correct yaml file

### DIFF
--- a/btx/diagnostics/bayesian_optimization.py
+++ b/btx/diagnostics/bayesian_optimization.py
@@ -435,8 +435,8 @@ class BayesianOptimization:
             The current config.
         setup : AttrDict
             The "setup" section of "config".
-        task_to_optimize : AttrDict
-            The section of "config" corresponding to the task to optimize.
+        task : AttrDict
+            The "bayesian_optimization" section of "config".
         params_names: List
             The names of the parameters to overwrite.
         new_input:

--- a/btx/diagnostics/bayesian_optimization.py
+++ b/btx/diagnostics/bayesian_optimization.py
@@ -446,8 +446,7 @@ class BayesianOptimization:
         config_dict = {key: dict(value) if value is not None else None for key, value in config.items()}
         # Overwrite the parameters
         for i, param_name in enumerate(params_names):
-            # config_dict[task.task_to_optimize][param_name] = float(new_input[i])
-            config_dict[task.task_to_optimize][param_name] = 50
+            config_dict[task.task_to_optimize][param_name] = float(new_input[i])
         # Overwrite the config file
         with open(config_file_path, 'w') as yaml_file:
             yaml.dump(config_dict, yaml_file, default_flow_style=False)

--- a/dags/plugins/jid.py
+++ b/dags/plugins/jid.py
@@ -93,7 +93,7 @@ class JIDSlurmOperator( BaseOperator ):
         # Return the task_id as is
         return task_id
     
-    def __new_config_path__(config_path, exp_name, branch_id):
+    def __new_config_path__(config_path, exp_name):
       config_dir, config_file_name = os.path.split(config_path)
       config_name, file_extension = os.path.splitext(config_file_name)
 
@@ -114,7 +114,7 @@ class JIDSlurmOperator( BaseOperator ):
         else:
           # The config file path does not need to be changed
           new_config_dir = config_dir
-          new_config_name = config_file_name
+          new_config_name = f"{exp_name}_bayesian_opt" + file_extension
 
       return os.path.join(new_config_dir, new_config_name)
     
@@ -122,7 +122,7 @@ class JIDSlurmOperator( BaseOperator ):
     # Overwrite the config file path
     config_path = context.get('dag_run').conf.get('parameters', {}).get('config_file')
     exp_name = context.get('dag_run').conf.get('experiment')
-    new_config_path = __new_config_path__(config_path, exp_name, self.branch_id)
+    new_config_path = __new_config_path__(config_path, exp_name)
     # Update the config_path directly
     context.get('dag_run').conf['parameters']['config_file'] = new_config_path
 

--- a/dags/plugins/jid.py
+++ b/dags/plugins/jid.py
@@ -102,19 +102,20 @@ class JIDSlurmOperator( BaseOperator ):
           new_config_dir = config_dir.rstrip(os.path.sep + "yamls")
           new_config_dir = os.path.join(new_config_dir, "bayesian_opt", exp_name + "_init_samples_configs")
         else:
+          # The config file path does not need to be changed
           new_config_dir = config_dir
 
         new_config_name = f"{exp_name}_sample_{self.branch_id}" + file_extension
 
       else:
         if "bayesian_opt" in config_dir:
-          new_config_name = f"{exp_name}_bayesian_opt" + file_extension
           new_config_dir = os.path.dirname(os.path.dirname(config_dir))
           new_config_dir = os.path.join(new_config_dir, "yamls")
         else:
           # The config file path does not need to be changed
           new_config_dir = config_dir
-          new_config_name = f"{exp_name}_bayesian_opt" + file_extension
+        
+        new_config_name = f"{exp_name}_bayesian_opt" + file_extension
 
       return os.path.join(new_config_dir, new_config_name)
     

--- a/tutorial/mfxx49820_bayesian_opt.yaml
+++ b/tutorial/mfxx49820_bayesian_opt.yaml
@@ -78,7 +78,8 @@ bayesian_optimization:
   loop_tasks: ["find_peaks", "index", "stream_analysis", "merge"]
   fom: "Rsplit"
   kernel: "rbf"
-  acquisition_function: "expected_improvement"
+  acquisition_function: "upper_confidence_bound"
+  beta: 2.0
   max_iterations: 10
   n_samples_init: 5
   n_points_per_param: 100


### PR DESCRIPTION
The "same score" bug comes from the fact that the run number is automatically added to the name of the config .yaml file.
When an non-existing config file is called, no error is shown but the BO task is not working. A possible fault has been identified in the JID where the new config file path is determined. The name of the config file has been hard-coded in one if/else case where it was not.