### PR TITLE
Pipca parallelization

### DIFF
--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -79,6 +79,12 @@ def display_dashboard(filename):
         first_compo = int(PC_scree[2:])
         last_compo = int(PC_scree2[2:])
 
+        if first_compo > last_compo:
+            raise ValueError("Error: First component cut-off cannot be greater than last component cut-off.")
+        
+        if last_compo >= len(PCs):
+            last_compo = len(PCs) - 1
+
         components = np.arange(first_compo,last_compo+1)
         singular_values = S[first_compo:last_compo]
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -111,7 +111,7 @@ def display_dashboard(filename):
         return heatmap
         
     # Define function to compute reconstructed heatmap based on tap location
-    def tap_heatmap_reconstruct(x, y, pcx, pcy, pcscree):
+    def tap_heatmap_reconstruct(x, y, pcx, pcy, pcscree, pcscree2):
         # Finds the index of image closest to the tap location
         img_source = closest_image_index(x, y, PCs[pcx], PCs[pcy])
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -123,7 +123,7 @@ def display_dashboard(filename):
         first_compo = int(pcscree[2:])
         last_compo = int(pcscree2[2:])
 
-        img = U[:, first_compo:last_compo] @ np.diag(S[first_compo:last_compo]) @ np.array([V[img_source][first_compo:last_compo]]).T
+        img = U[:, first_compo-1:last_compo] @ np.diag(S[first_compo-1:last_compo]) @ np.array([V[img_source][first_compo-1:last_compo]]).T
         img = img.reshape((p, x, y))
         img = assemble_image_stack_batch(img, pixel_index_map)
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -75,7 +75,7 @@ def display_dashboard(filename):
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
         components = np.arange(1,q+1)
-        singular_values = S[:q]
+        singular_values = S[-q:]
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,
@@ -114,7 +114,7 @@ def display_dashboard(filename):
         pixel_index_map = retrieve_pixel_index_map(psi.det.geometry(psi.run))
 
         q = int(pcscree[2:])
-        img = U[:, :q] @ np.diag(S[:q]) @ np.array([V[img_source][:q]]).T
+        img = U[:, -q:] @ np.diag(S[-q:]) @ np.array([V[img_source][-q:]]).T
         img = img.reshape((p, x, y))
         img = assemble_image_stack_batch(img, pixel_index_map)
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -74,8 +74,8 @@ def display_dashboard(filename):
     @pn.depends(PC_scree.param.value)
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
-        components = np.arange(1, q + 1)
-        singular_values = S[:q]
+        components = np.arange(q, len(PCs) + 1)
+        singular_values = S[q:]
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -74,8 +74,8 @@ def display_dashboard(filename):
     @pn.depends(PC_scree.param.value)
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
-        components = np.arange(q, len(PCs)) #CHANGED HERE
-        singular_values = S[q:] #CHANGED HERE
+        components = np.arange(1, q + 1)
+        singular_values = S[:q]
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,
@@ -114,7 +114,7 @@ def display_dashboard(filename):
         pixel_index_map = retrieve_pixel_index_map(psi.det.geometry(psi.run))
 
         q = int(pcscree[2:])
-        img = U[:, q:] @ np.diag(S[q:]) @ np.array([V[img_source][q:]]).T #CHANGED HERE
+        img = U[:, :q] @ np.diag(S[:q]) @ np.array([V[img_source][:q]]).T
         img = img.reshape((p, x, y))
         img = assemble_image_stack_batch(img, pixel_index_map)
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -74,8 +74,8 @@ def display_dashboard(filename):
     @pn.depends(PC_scree.param.value)
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
-        components = np.arange(q, len(PCs) + 1)
-        singular_values = S[q:]
+        components = np.arange(1,q+1)
+        singular_values = S[:q]
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -92,7 +92,7 @@ def display_dashboard(filename):
         return scree
         
     # Define function to compute heatmap based on tap location
-    def tap_heatmap(x, y, pcx, pcy, pcscree):
+    def tap_heatmap(x, y, pcx, pcy, pcscree, pcscree2):
         # Finds the index of image closest to the tap location
         img_source = closest_image_index(x, y, PCs[pcx], PCs[pcy])
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -334,6 +334,11 @@ def compute_compression_loss(filename, num_components, random_images=False, num_
         # Compute the Frobenius norm of the difference between the original image and the reconstructed image
         difference = np.abs(img - reconstructed_img)
         norm = np.linalg.norm(difference, 'fro')
+        original_norm = np.linalg.norm(img, 'fro')
+
+        # Normalize the norm by the original norm
+        norm /= original_norm
+
         image_norms.append(norm)
 
         psi.counter = counter  # Reset counter for the next iteration

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -51,10 +51,8 @@ def display_dashboard(filename):
     widgets_scatter = pn.WidgetBox(PCx, PCy, width=150)
 
     PC_scree = pnw.Select(name='First Component Cut-off', value=f'PC{len(PCs)}', options=PC_options)
-    widgets_scree = pn.WidgetBox(PC_scree, width=150)
-
     PC_scree2 = pnw.Select(name='Last Component Cut-off', value=f'PC{len(PCs)}', options=PC_options)
-    widgets_scree = pn.WidgetBox(PC_scree2, width=150)
+    widgets_scree = pn.WidgetBox(PC_scree,PC_scree2, width=150)
 
     tap_source = None
     posxy = hv.streams.Tap(source=tap_source, x=0, y=0)

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -74,7 +74,7 @@ def display_dashboard(filename):
     @pn.depends(PC_scree.param.value)
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
-        components = np.arange(1, q + 1)
+        components = np.arange(q, len(PCs)) #CHANGED HERE
         singular_values = S[q:] #CHANGED HERE
         bars_data = np.stack((components, singular_values)).T
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -75,7 +75,7 @@ def display_dashboard(filename):
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
         components = np.arange(1,q+1)
-        singular_values = S[-q:]
+        singular_values = S[:q]
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,
@@ -114,7 +114,7 @@ def display_dashboard(filename):
         pixel_index_map = retrieve_pixel_index_map(psi.det.geometry(psi.run))
 
         q = int(pcscree[2:])
-        img = U[:, -q:] @ np.diag(S[-q:]) @ np.array([V[img_source][-q:]]).T
+        img = U[:, :q] @ np.diag(S[:q]) @ np.array([V[img_source][:q]]).T
         img = img.reshape((p, x, y))
         img = assemble_image_stack_batch(img, pixel_index_map)
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -50,7 +50,7 @@ def display_dashboard(filename):
     PCy = pnw.Select(name='Y-Axis', value='PC2', options=PC_options)
     widgets_scatter = pn.WidgetBox(PCx, PCy, width=150)
 
-    PC_scree = pnw.Select(name='First Component Cut-off', value=f'PC{len(PCs)}', options=PC_options)
+    PC_scree = pnw.Select(name='First Component Cut-off', value=f'PC{1}', options=PC_options)
     PC_scree2 = pnw.Select(name='Last Component Cut-off', value=f'PC{len(PCs)}', options=PC_options)
     widgets_scree = pn.WidgetBox(PC_scree,PC_scree2, width=150)
 
@@ -79,9 +79,6 @@ def display_dashboard(filename):
 
         if first_compo >= last_compo:
             raise ValueError("Error: First component cut-off cannot be greater than last component cut-off.")
-        
-        if last_compo >= len(PCs):
-            last_compo = len(PCs) - 1
 
         components = np.arange(first_compo,last_compo+1)
         singular_values = S[first_compo:last_compo]

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -77,7 +77,7 @@ def display_dashboard(filename):
         first_compo = int(PC_scree[2:])
         last_compo = int(PC_scree2[2:])
 
-        if first_compo > last_compo:
+        if first_compo >= last_compo:
             raise ValueError("Error: First component cut-off cannot be greater than last component cut-off.")
         
         if last_compo >= len(PCs):

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -75,7 +75,7 @@ def display_dashboard(filename):
         
     # Create scree plot
     @pn.depends(PC_scree.param.value, PC_scree2.param.value)
-    def create_scree(PC_scree):
+    def create_scree(PC_scree, PC_scree2):
         first_compo = int(PC_scree[2:])
         last_compo = int(PC_scree2[2:])
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -75,7 +75,7 @@ def display_dashboard(filename):
     def create_scree(PC_scree):
         q = int(PC_scree[2:])
         components = np.arange(1, q + 1)
-        singular_values = S[:q]
+        singular_values = S[q:] #CHANGED HERE
         bars_data = np.stack((components, singular_values)).T
 
         opts = dict(width=400, height=300, show_grid=True, show_legend=False,
@@ -114,7 +114,7 @@ def display_dashboard(filename):
         pixel_index_map = retrieve_pixel_index_map(psi.det.geometry(psi.run))
 
         q = int(pcscree[2:])
-        img = U[:, :q] @ np.diag(S[:q]) @ np.array([V[img_source][:q]]).T
+        img = U[:, q:] @ np.diag(S[q:]) @ np.array([V[img_source][q:]]).T #CHANGED HERE
         img = img.reshape((p, x, y))
         img = assemble_image_stack_batch(img, pixel_index_map)
 

--- a/btx/misc/pipca_visuals.py
+++ b/btx/misc/pipca_visuals.py
@@ -77,11 +77,11 @@ def display_dashboard(filename):
         first_compo = int(PC_scree[2:])
         last_compo = int(PC_scree2[2:])
 
-        if first_compo >= last_compo:
+        if first_compo > last_compo:
             raise ValueError("Error: First component cut-off cannot be greater than last component cut-off.")
 
         components = np.arange(first_compo,last_compo+1)
-        singular_values = S[first_compo:last_compo]
+        singular_values = S[first_compo-1:last_compo]
 
         bars_data = np.stack((components, singular_values)).T
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -174,20 +174,15 @@ class PiPCA:
                 self.data_loaded = None
                 if self.rank==0:
                     formatted_imgs = self.get_formatted_images(batch_size,self.split_indices[0],self.split_indices[1])
-                    logging.info(f"Data_loaded : {self.data_loaded is not None}")
+                    self.comm.bcast(self.data_loaded, root=0)
                 
                 self.comm.Barrier()
-                logging.info("Barrière passée")
                 if self.rank==0:
-                    logging.info("Le rank 0 va bien update")
                     self.update_model(formatted_imgs)
-                
-                self.data_loaded = self.comm.bcast(self.data_loaded, root=0)
 
-                self.comm.Barrier()
-                
-                else:
+                if self.rank !=0:
                     logging.info(f"On lance bien le reste, rank : {self.rank}")
+                    self.data_loaded = self.comm.bcast(None,root=0)
                     logging.info(f"La data est toujours loadée : {self.data_loaded is not None}")
                     self.fetch_and_update_model(batch_size)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -222,12 +222,6 @@ class PiPCA:
                     std_deviation = statistics.stdev(durations)
                     logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
-        if self.rank==1:
-            for task, durations in self.task_durations.items():
-                if task == 'receiving images':
-                    mean_duration = np.mean(durations)
-                    std_deviation = statistics.stdev(durations)
-                    logging.info(f"Task :{task}, Mean Duration {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
         self.comm.Barrier()
 
     def get_formatted_images(self, n, start_index, end_index):
@@ -254,23 +248,15 @@ class PiPCA:
 
         # may have to rewrite eventually when number of images becomes large,
         # i.e. streamed setting, either that or downsample aggressively
-        if not self.data_loaded :
+        if self.data_loaded is None :
             with TaskTimer(self.task_durations, 'get images first rank'):
                 imgs = self.psi.get_images(n,assemble=False)
                 self.data_loaded = imgs
 
         else:
-            imgs = self.data_loaded
+            with TaskTimer(self.task_durations, 'get images other ranks'):
+                imgs = self.data_loaded
             
-"""            with TaskTimer(self.task_durations, 'broadcasting images'):
-                imgs = self.comm.bcast(imgs,root=0)
-                    
-        else :
-            logging.info("Receiving other ranks")
-            with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.recv(source=0)
-            logging.info("Received other ranks")
-"""
         if downsample:
             imgs = bin_data(imgs, bin_factor)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -224,7 +224,7 @@ class PiPCA:
 
         if self.rank==1:
             for task, durations in self.task_durations.items():
-                if task = 'receiving images':
+                if task == 'receiving images':
                     mean_duration = np.mean(durations)
                     std_deviation = stastistics.stdev(durations)
                     logging.info(f"Task :{task}, Mean Duration {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -185,7 +185,6 @@ class PiPCA:
         end_time = time.time()
         logging.basicConfig(level=logging.INFO)
 
-        logging.info(f"Rank used : {self.rank}")
         if self.rank == 0:  
             logging.info("Model complete")
             execution_time = end_time - start_time  # Calculate the execution time
@@ -259,13 +258,13 @@ class PiPCA:
             with TaskTimer(self.task_durations, 'get images rank 0'):
                 imgs = self.psi.get_images(n,assemble=False)
 
-            with TaskTimer(self.task_durations, 'sending images'):
+            with TaskTimer(self.task_durations, 'broadcasting images'):
                 for i in range(1, self.size):
-                    self.comm.send(imgs,dest=i,tag=0)
+                    self.comm.bcast(imgs,root=0)
                     
-        else:
+        else :
             with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.recv(source=0,tag=0)
+                imgs = self.comm.bcast(None,root=0)
 
         if downsample:
             imgs = bin_data(imgs, bin_factor)

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -271,7 +271,7 @@ class PiPCA:
         num_valid_imgs, p, x, y = imgs.shape
         formatted_imgs = np.reshape(imgs, (num_valid_imgs, p * x * y)).T
 
-        formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices)
+        formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices[1:])
 
         #for i in range(0,self.comm.Get_size()):
         #    formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -182,9 +182,12 @@ class PiPCA:
                     logging.info("Le rank 0 va bien update")
                     self.update_model(formatted_imgs)
                 
+                self.data_loaded = self.comm.bcast(self.data_loaded, root=0)
+
+                self.comm.Barrier()
+                
                 else:
                     logging.info(f"On lance bien le reste, rank : {self.rank}")
-                    self.data_loaded = self.comm.bcast(self.data_loaded, root=0)
                     logging.info(f"La data est toujours loadée : {self.data_loaded is not None}")
                     self.fetch_and_update_model(batch_size)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -271,7 +271,8 @@ class PiPCA:
         num_valid_imgs, p, x, y = imgs.shape
         formatted_imgs = np.reshape(imgs, (num_valid_imgs, p * x * y)).T
 
-        formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices[1:])
+        formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices[1:-1])
+        logging.info(formatted_imgs_to_scatter[0])
 
         #for i in range(0,self.comm.Get_size()):
         #    formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -226,7 +226,7 @@ class PiPCA:
             for task, durations in self.task_durations.items():
                 if task == 'receiving images':
                     mean_duration = np.mean(durations)
-                    std_deviation = stastistics.stdev(durations)
+                    std_deviation = statistics.stdev(durations)
                     logging.info(f"Task :{task}, Mean Duration {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
         self.comm.Barrier()
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -261,6 +261,7 @@ class PiPCA:
             with TaskTimer(self.task_durations, 'broadcasting images'):
                 imgs = self.comm.bcast(imgs,root=0)
                     
+        else :
             with TaskTimer(self.task_durations,'receiving images'):
                 imgs = self.comm.bcast(None, root=0)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -173,7 +173,7 @@ class PiPCA:
             for batch_size in batch_sizes:
                 self.data_loaded = None
                 if self.rank==0:
-                    formatted_imgs = self.get_formatted_images(bath_size,self.split_indices[0],self.split_indices[1])
+                    formatted_imgs = self.get_formatted_images(batch_size,self.split_indices[0],self.split_indices[1])
                     logging.info(f"Data_loaded : {self.data_loaded is not None}")
                 
                 self.comm.Barrier()

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -173,15 +173,26 @@ class PiPCA:
             for batch_size in batch_sizes:
                 if self.rank==0:
                     img_batch = []
-                    imgs = self.psi.get_images(batch_size,assemble=False)
-                    for i in range(0,self.comm.Get_size()):
-                        img_batch.append(get_formatted_images(imgs,self.split_indices[i], self.split_indices[i + 1]))
-
+                    with TaskTimer(self.task_durations, "get formatted images rank 0"):
+                        logging.info('Checkpoint 1')
+                        imgs = self.psi.get_images(batch_size,assemble=False)
+                        for i in range(0,self.comm.Get_size()):
+                            logging.info('Checkpoint 2')
+                            img_batch.append(self.get_formatted_images(imgs,self.split_indices[i], self.split_indices[i + 1]))
+                            logging.info('Checkpoint 3')
                 else :
                     img_batch = None
                 
-                formatted_imgs = self.comm.scatter(img_batch,root=0) 
-                self.update_model(formatted_imgs)
+                self.comm.Barrier()
+
+                with TaskTimer(self.task_durations, "scattering data to all ranks"):
+                    logging.info('Checkpoint 4')
+                    formatted_imgs = self.comm.scatter(img_batch,root=0) 
+                    logging.info(f'Checkpoint 5, data_loaded : {formatted_imgs is not None}, Rank : {self.rank}')
+                
+                with TaskTimer(self.task_durations, "update model"):
+                    self.update_model(formatted_imgs)
+                    logging.info('Checkpoint 6')
 
         self.comm.Barrier()
         

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -222,6 +222,7 @@ class PiPCA:
                     append_to_dataset(f, 'execution_times', data=execution_time)
                     logging.info(f'Model saved to {self.filename}')
 
+        if self.rank==1:
             # Print the mean duration and standard deviation for each task
             for task, durations in self.task_durations.items():
                 durations = [float(round(float(duration), 2)) for duration in durations]  # Convert to float and round to 2 decimal places

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -259,7 +259,7 @@ class PiPCA:
                 imgs = self.psi.get_images(n,assemble=False)
 
             with TaskTimer(self.task_durations, 'broadcasting images'):
-                self.comm.bcast(imgs,root=0)
+                imgs = self.comm.bcast(imgs,root=0)
                     
         else :
             with TaskTimer(self.task_durations,'receiving images'):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -263,7 +263,7 @@ class PiPCA:
                     
         else :
             with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.bcast(None,root=0)
+                imgs = self.comm.recv(source=0)
 
         if downsample:
             imgs = bin_data(imgs, bin_factor)

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -273,6 +273,8 @@ class PiPCA:
 
         formatted_imgs_to_scatter = []
 
+        logging.info(self.split_indices)
+        
         for i in range(0,self.comm.Get_size()):
             formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])
 
@@ -307,24 +309,6 @@ class PiPCA:
         self.V = V_T.T
 
         self.num_incorporated_images += n
-
-    def fetch_and_update_model(self, n):
-        """
-        Fetch images and update model.
-
-        Parameters
-        ----------
-        n : int
-            number of images to incorporate
-        """
-
-        rank = self.rank
-        start_index, end_index = self.split_indices[rank], self.split_indices[rank + 1]
-
-        with TaskTimer(self.task_durations, "get formatted images"):
-            img_batch = self.get_formatted_images(n, start_index, end_index)
-
-        self.update_model(img_batch)
 
     def update_model(self, X):
         """

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -259,8 +259,7 @@ class PiPCA:
                 imgs = self.psi.get_images(n,assemble=False)
 
             with TaskTimer(self.task_durations, 'broadcasting images'):
-                for i in range(1, self.size):
-                    self.comm.bcast(imgs,root=0)
+                self.comm.bcast(imgs,root=0)
                     
         else :
             with TaskTimer(self.task_durations,'receiving images'):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -188,7 +188,7 @@ class PiPCA:
                 with TaskTimer(self.task_durations, "update model"):
                     self.update_model(formatted_imgs)
 
-        self.comm.Barrier()
+        #self.comm.Barrier()
         
         with TaskTimer(self.task_durations, "gather matrices end"):
             U = self.gather_U()
@@ -237,9 +237,7 @@ class PiPCA:
                     logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
         self.comm.Barrier()
-        end_time=time.time()
-        logging.info(f"Total execution time : {end_time-start_time}")
-        
+
     def get_formatted_images(self, imgs):
         """
         Fetch n - x image segments from run, where x is the number of 'dead' images.

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -184,6 +184,7 @@ class PiPCA:
                 
                 else:
                     logging.info(f"On lance bien le reste, rank : {self.rank}")
+                    logging.info(f"La data est toujours loadée : {self.data_loaded is not None}")
                     self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()
@@ -245,7 +246,7 @@ class PiPCA:
                     std_deviation = statistics.stdev(durations)
                     logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
             logging.info("END RANK 1 ===========================")
-            
+
         self.comm.Barrier()
 
     def get_formatted_images(self, n, start_index, end_index):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -171,18 +171,9 @@ class PiPCA:
         # update model with remaining batches
         with TaskTimer(self.task_durations, "fetch and update model"):
             for batch_size in batch_sizes:
-                self.data_loaded = None
-
-                self.comm.Barrier()
-
-                if self.rank ==0:
-                    self.fetch_and_update_model(batch_size)
-                
-                self.comm.Barrier()
-
-                if self.rank !=0:
-                    logging.info(f"Barrière passée par le rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
-                    self.fetch_and_update_model(batch_size)
+                if self.rank == 0:
+                    self.data_loaded = None
+                self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()
         

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -171,12 +171,16 @@ class PiPCA:
         # update model with remaining batches
         with TaskTimer(self.task_durations, "fetch and update model"):
             for batch_size in batch_sizes:
-                if self.rank==0:
-                    self.data_loaded = None
+                self.data_loaded = None
+
+                self.comm.Barrier()
+
+                if self.rank ==0:
                     self.fetch_and_update_model(batch_size)
-                    self.comm.Barrier()
-                else:
-                    self.comm.Barrier()
+                
+                self.comm.Barrier()
+
+                if self.rank !=0:
                     logging.info(f"Barrière passée par le rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
                     self.fetch_and_update_model(batch_size)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -271,12 +271,10 @@ class PiPCA:
         num_valid_imgs, p, x, y = imgs.shape
         formatted_imgs = np.reshape(imgs, (num_valid_imgs, p * x * y)).T
 
-        formatted_imgs_to_scatter = []
+        formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices)
 
-        logging.info(self.split_indices)
-        
-        for i in range(0,self.comm.Get_size()):
-            formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])
+        #for i in range(0,self.comm.Get_size()):
+        #    formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])
 
         return formatted_imgs_to_scatter
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -172,8 +172,17 @@ class PiPCA:
         with TaskTimer(self.task_durations, "fetch and update model"):
             for batch_size in batch_sizes:
                 self.data_loaded = None
+                if self.rank==0:
+                    formatted_imgs = self.get_formatted_images(bath_size,self.split_indices[0],self.split_indices[1])
+                    logging.info(f"Data_loaded : {self.data_loaded is not None}")
+                
+                self.comm.Barrier()
 
-                self.fetch_and_update_model(batch_size)
+                if self.rank==0:
+                    self.update_model(formatted_imgs)
+                
+                else:
+                    self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()
         

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -133,7 +133,7 @@ class PiPCA:
 
         batch_size = self.batch_size
         num_images = self.num_images
-
+        
         # initialize and prime model, if specified
         if self.priming:
             img_batch = self.get_formatted_images(
@@ -1187,7 +1187,11 @@ if __name__ == "__main__":
     params = parse_input()
     kwargs = {k: v for k, v in vars(params).items() if v is not None}
 
-    pipca = PiPCA(**kwargs)
-    pipca.run()
-    pipca.get_outliers()
+    overall_execution_timer = tasktime.Timer('Overall execution time')
 
+    with overall_execution_timer:
+        pipca = PiPCA(**kwargs)
+        pipca.run()
+        pipca.get_outliers()
+
+    logging.info(f"Total execution time : {overall_execution_timer}")

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -188,7 +188,7 @@ class PiPCA:
                 with TaskTimer(self.task_durations, "update model"):
                     self.update_model(formatted_imgs)
 
-        #self.comm.Barrier()
+        self.comm.Barrier()
         
         with TaskTimer(self.task_durations, "gather matrices end"):
             U = self.gather_U()

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -261,9 +261,8 @@ class PiPCA:
             with TaskTimer(self.task_durations, 'broadcasting images'):
                 imgs = self.comm.bcast(imgs,root=0)
                     
-        else :
             with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.recv(source=0)
+                imgs = self.comm.bcast(None, root=0)
 
         if downsample:
             imgs = bin_data(imgs, bin_factor)

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -176,7 +176,7 @@ class PiPCA:
                     self.fetch_and_update_model(batch_size)
 
                 self.comm.Barrier()
-
+                logging.info(f"Barrière passée par le rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
                 if self.rank !=0:
                     self.fetch_and_update_model(batch_size)
     
@@ -251,8 +251,6 @@ class PiPCA:
 
         bin_factor = self.bin_factor
         downsample = self.downsample
-
-        logging.info(f"Rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
         # may have to rewrite eventually when number of images becomes large,
         # i.e. streamed setting, either that or downsample aggressively
         if self.data_loaded is None :

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -62,6 +62,7 @@ class PiPCA:
         self.bin_factor = bin_factor
         self.output_dir = output_dir
         self.filename = filename
+        self.data_loaded = None
 
         (
             self.num_images,
@@ -258,12 +259,17 @@ class PiPCA:
             with TaskTimer(self.task_durations, 'get images rank 0'):
                 imgs = self.psi.get_images(n,assemble=False)
 
-            with TaskTimer(self.task_durations, 'broadcasting images'):
+                self.data_loaded = imgs
+        
+        else:
+            imgs = self.data_loaded
+
+"""            with TaskTimer(self.task_durations, 'broadcasting images'):
                 imgs = self.comm.bcast(imgs,root=0)
                     
         else :
             with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.bcast(None, root=0)
+                imgs = self.comm.bcast(None, root=0)"""
 
         if downsample:
             imgs = bin_data(imgs, bin_factor)

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -239,9 +239,9 @@ class PiPCA:
                     std_deviation = statistics.stdev(durations)
                     logging.debug(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
-        end_time = time.time()
-        logging.info(f"Model complete in {end_time - start_time} seconds")
-        
+            end_time = time.time()
+            logging.info(f"Model complete in {end_time - start_time} seconds")
+
         self.comm.Barrier()
 
     def get_formatted_images(self, imgs):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -262,7 +262,8 @@ class PiPCA:
                 self.data_loaded = imgs
         
         else:
-            imgs = self.data_loaded
+            with TaskTimer(self.task_durations, 'get images other ranks'):
+                imgs = self.data_loaded
 
 """            with TaskTimer(self.task_durations, 'broadcasting images'):
                 imgs = self.comm.bcast(imgs,root=0)

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -171,8 +171,8 @@ class PiPCA:
         # update model with remaining batches
         with TaskTimer(self.task_durations, "fetch and update model"):
             for batch_size in batch_sizes:
-                if self.rank == 0:
-                    self.data_loaded = None
+                self.data_loaded = None
+
                 self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -63,7 +63,7 @@ class PiPCA:
         self.output_dir = output_dir
         self.filename = filename
         self.data_loaded = None
-
+        
         (
             self.num_images,
             self.num_components,
@@ -260,8 +260,10 @@ class PiPCA:
                 imgs = self.psi.get_images(n,assemble=False)
 
                 self.data_loaded = imgs
-        
-        else:
+
+        self.comm.Barrier()
+
+        if self.rank !=0:
             with TaskTimer(self.task_durations, 'get images other ranks'):
                 imgs = self.data_loaded
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -173,7 +173,12 @@ class PiPCA:
             for batch_size in batch_sizes:
                 if self.rank==0:
                     self.data_loaded = None
-                self.fetch_and_update_model(batch_size)
+                    self.fetch_and_update_model(batch_size)
+                    self.comm.Barrier()
+                else:
+                    self.comm.Barrier()
+                    logging.info(f"Barrière passée par le rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
+                    self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()
         

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -63,7 +63,7 @@ class PiPCA:
         self.output_dir = output_dir
         self.filename = filename
         self.data_loaded = None
-        
+
         (
             self.num_images,
             self.num_components,
@@ -254,26 +254,23 @@ class PiPCA:
 
         # may have to rewrite eventually when number of images becomes large,
         # i.e. streamed setting, either that or downsample aggressively
-
-        if self.rank ==0:
-            with TaskTimer(self.task_durations, 'get images rank 0'):
+        if not self.data_loaded :
+            with TaskTimer(self.task_durations, 'get images first rank'):
                 imgs = self.psi.get_images(n,assemble=False)
-
                 self.data_loaded = imgs
 
-        self.comm.Barrier()
-
-        if self.rank !=0:
-            with TaskTimer(self.task_durations, 'get images other ranks'):
-                imgs = self.data_loaded
-
+        else:
+            imgs = self.data_loaded
+            
 """            with TaskTimer(self.task_durations, 'broadcasting images'):
                 imgs = self.comm.bcast(imgs,root=0)
                     
         else :
+            logging.info("Receiving other ranks")
             with TaskTimer(self.task_durations,'receiving images'):
-                imgs = self.comm.bcast(None, root=0)"""
-
+                imgs = self.comm.recv(source=0)
+            logging.info("Received other ranks")
+"""
         if downsample:
             imgs = bin_data(imgs, bin_factor)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -184,6 +184,7 @@ class PiPCA:
                 
                 else:
                     logging.info(f"On lance bien le reste, rank : {self.rank}")
+                    self.data_loaded = self.comm.bcast(self.data_loaded, root=0)
                     logging.info(f"La data est toujours loadée : {self.data_loaded is not None}")
                     self.fetch_and_update_model(batch_size)
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -272,10 +272,6 @@ class PiPCA:
         formatted_imgs = np.reshape(imgs, (num_valid_imgs, p * x * y)).T
 
         formatted_imgs_to_scatter = np.split(formatted_imgs, self.split_indices[1:-1])
-        logging.info(formatted_imgs_to_scatter[0])
-
-        #for i in range(0,self.comm.Get_size()):
-        #    formatted_imgs_to_scatter.append(formatted_imgs[self.split_indices[i]:self.split_indices[i + 1],:])
 
         return formatted_imgs_to_scatter
 

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -171,22 +171,29 @@ class PiPCA:
         # update model with remaining batches
         with TaskTimer(self.task_durations, "formatting and update model"):
             for batch_size in batch_sizes:
-                with TaskTimer(self.task_durations, "get images on each rank - equiv to old get_formatted_img"):
-                    if self.rank==0:
-                        with TaskTimer(self.task_durations, "get formatted images rank 0"):
-                            imgs = self.psi.get_images(batch_size,assemble=False)
-                            with TaskTimer(self.task_durations, "distribute pixels"):
-                                img_batch = self.get_formatted_images(imgs)
-                    else :
-                        img_batch = None
-                    
-                    self.comm.Barrier()
+                if self.size ==1:
+                    imgs = self.psi.get_images(batch_size,assemble=False)
+                    img_batch = self.get_formatted_images(imgs)[0]
 
-                    with TaskTimer(self.task_durations, "scattering data to all ranks"):
-                        formatted_imgs = self.comm.scatter(img_batch,root=0) 
+                    self.update_model(img_batch)
                     
-                with TaskTimer(self.task_durations, "update model"):
-                    self.update_model(formatted_imgs)
+                else:
+                    with TaskTimer(self.task_durations, "get images on each rank - equiv to old get_formatted_img"):
+                        if self.rank==0:
+                            with TaskTimer(self.task_durations, "get formatted images rank 0"):
+                                imgs = self.psi.get_images(batch_size,assemble=False)
+                                with TaskTimer(self.task_durations, "distribute pixels"):
+                                    img_batch = self.get_formatted_images(imgs)
+                        else :
+                            img_batch = None
+                        
+                        self.comm.Barrier()
+
+                        with TaskTimer(self.task_durations, "scattering data to all ranks"):
+                            formatted_imgs = self.comm.scatter(img_batch,root=0) 
+                        
+                    with TaskTimer(self.task_durations, "update model"):
+                        self.update_model(formatted_imgs)
 
         self.comm.Barrier()
         

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -204,7 +204,7 @@ class PiPCA:
         logging.basicConfig(level=logging.INFO)
 
         if self.rank == 0:  
-            logging.info("Model complete")
+            logging.debug("Model complete")
             execution_time = end_time - start_time  # Calculate the execution time
             frequency = self.num_incorporated_images/execution_time
 
@@ -227,18 +227,21 @@ class PiPCA:
 
                     append_to_dataset(f, 'frequency', data=frequency)
                     append_to_dataset(f, 'execution_times', data=execution_time)
-                    logging.info(f'Model saved to {self.filename}')
+                    logging.debug(f'Model saved to {self.filename}')
 
             # Print the mean duration and standard deviation for each task
             for task, durations in self.task_durations.items():
                 durations = [float(round(float(duration), 2)) for duration in durations]  # Convert to float and round to 2 decimal places
                 if len(durations) == 1:
-                    logging.info(f"Task: {task}, Duration: {durations[0]:.2f} (Only 1 duration)")
+                    logging.debug(f"Task: {task}, Duration: {durations[0]:.2f} (Only 1 duration)")
                 else:
                     mean_duration = np.mean(durations)
                     std_deviation = statistics.stdev(durations)
-                    logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
+                    logging.debug(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
+        end_time = time.time()
+        logging.info(f"Model complete in {end_time - start_time} seconds")
+        
         self.comm.Barrier()
 
     def get_formatted_images(self, imgs):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -177,11 +177,13 @@ class PiPCA:
                     logging.info(f"Data_loaded : {self.data_loaded is not None}")
                 
                 self.comm.Barrier()
-
+                logging.info("Barrière passée")
                 if self.rank==0:
+                    logging.info("Le rank 0 va bien update")
                     self.update_model(formatted_imgs)
                 
                 else:
+                    logging.info(f"On lance bien le reste, rank : {self.rank}")
                     self.fetch_and_update_model(batch_size)
 
         self.comm.Barrier()
@@ -222,7 +224,6 @@ class PiPCA:
                     append_to_dataset(f, 'execution_times', data=execution_time)
                     logging.info(f'Model saved to {self.filename}')
 
-        if self.rank==1:
             # Print the mean duration and standard deviation for each task
             for task, durations in self.task_durations.items():
                 durations = [float(round(float(duration), 2)) for duration in durations]  # Convert to float and round to 2 decimal places
@@ -233,6 +234,18 @@ class PiPCA:
                     std_deviation = statistics.stdev(durations)
                     logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
+        if self.rank==1:
+            logging.info("RANK 1 ============================")
+            for task, durations in self.task_durations.items():
+                durations = [float(round(float(duration), 2)) for duration in durations]  # Convert to float and round to 2 decimal places
+                if len(durations) == 1:
+                    logging.info(f"Task: {task}, Duration: {durations[0]:.2f} (Only 1 duration)")
+                else:
+                    mean_duration = np.mean(durations)
+                    std_deviation = statistics.stdev(durations)
+                    logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
+            logging.info("END RANK 1 ===========================")
+            
         self.comm.Barrier()
 
     def get_formatted_images(self, n, start_index, end_index):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -171,15 +171,10 @@ class PiPCA:
         # update model with remaining batches
         with TaskTimer(self.task_durations, "fetch and update model"):
             for batch_size in batch_sizes:
-                self.data_loaded = None
                 if self.rank==0:
-                    self.fetch_and_update_model(batch_size)
+                    self.data_loaded = None
+                self.fetch_and_update_model(batch_size)
 
-                self.comm.Barrier()
-                logging.info(f"Barrière passée par le rank : {self.rank}, Data loaded : {self.data_loaded is not None}")
-                if self.rank !=0:
-                    self.fetch_and_update_model(batch_size)
-    
         self.comm.Barrier()
         
         with TaskTimer(self.task_durations, "gather matrices end"):

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -237,7 +237,9 @@ class PiPCA:
                     logging.info(f"Task: {task}, Mean Duration: {mean_duration:.2f}, Standard Deviation: {std_deviation:.2f}")
 
         self.comm.Barrier()
-
+        end_time=time.time()
+        logging.info(f"Total execution time : {end_time-start_time}")
+        
     def get_formatted_images(self, imgs):
         """
         Fetch n - x image segments from run, where x is the number of 'dead' images.
@@ -1187,11 +1189,7 @@ if __name__ == "__main__":
     params = parse_input()
     kwargs = {k: v for k, v in vars(params).items() if v is not None}
 
-    overall_execution_timer = tasktime.Timer('Overall execution time')
+    pipca = PiPCA(**kwargs)
+    pipca.run()
+    pipca.get_outliers()
 
-    with overall_execution_timer:
-        pipca = PiPCA(**kwargs)
-        pipca.run()
-        pipca.get_outliers()
-
-    logging.info(f"Total execution time : {overall_execution_timer}")

--- a/btx/processing/pipca.py
+++ b/btx/processing/pipca.py
@@ -174,7 +174,9 @@ class PiPCA:
                 self.data_loaded = None
                 if self.rank==0:
                     formatted_imgs = self.get_formatted_images(batch_size,self.split_indices[0],self.split_indices[1])
+                    logging.info("Checkpoint 1")
                     self.comm.bcast(self.data_loaded, root=0)
+                    logging.info("Checkpoint 2")
                 
                 self.comm.Barrier()
                 if self.rank==0:


### PR DESCRIPTION
###  Parallelization of the retrieving and formatting of images

Previously, all ranks were loading all the images, meaning that the execution time was increasing as the number of ranks was increasing. Now only the rank 0 loads all the images and then scatters the pixels to their corresponding rank: the execution time is much shorter. It can't be reduced more as the images somewhat have to be all loaded. However one can note that it's still scaling with the number of ranks, which is normal as the scattering scales lightly with the number of ranks. 
_(Note: for all following graphs, 10 batches of 100 images were used, with 8 components used)_

![Comparison](https://github.com/lcls-users/btx/assets/107032308/faeb6021-8c2e-4de3-8796-776b31344a78)

![Contribution](https://github.com/lcls-users/btx/assets/107032308/339ba468-2591-4860-8d44-f38282afd7b6)

At higher number of ranks, the reduction of the execution time of the QR factorization due to parallelization is larger than the slight increase in execution time of the scattering, and as such the overall execution time decreases with parallelization!

![Overall](https://github.com/lcls-users/btx/assets/107032308/cf6a4b48-cef6-44b6-aa53-16be76b74946)

I also switched the execution times of each process to a debugging level and modified the computing of the compression loss norm to make it relative to the original norm.

I also updated the dashboard display : we can now select more precisely the components we want to keep (first and last cut-offs).

### Future steps

Note that each rank will have to load each eigenimages, meaning that the more ranks and the more components the algorithm is reducing the images to, the more memory is needed. For instance, with 30 batches of 10 images, 300 components can be computed with 40 ranks on S3DF, but an out-of-memory error is raised for 100 ranks.