### PR TITLE
Add events mask

### DIFF
--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -35,6 +35,17 @@ class RunDiagnostics:
         self.rank = self.comm.Get_rank()
         self.size = self.comm.Get_size() 
 
+    def init_base_powders(self):
+        """
+        Initialize the base powders: sum, sum of squares, max, and min.
+        Parameters
+        ----------
+        img_shape : tuple, 3d
+            The shape of unassembled, calibrated images: (n_panels, n_x, n_y)
+        """
+        for key in ['sum', 'sqr', 'max', 'min']:
+            self.powders[key] = np.zeros(self.psi.det.shape())
+
     def compute_base_powders(self, img):
         """
         Compute the base powders: max, sum, sum of squares.
@@ -61,16 +72,10 @@ class RunDiagnostics:
         """
         self.powders_final = dict()
         total_n_proc = self.comm.reduce(self.n_proc, MPI.SUM)
-        if total_n_proc == 0:
-            powder_max = np.zeros(self.psi.det.shape())
-            powder_min = np.zeros(self.psi.det.shape())
-            powder_sum = np.zeros(self.psi.det.shape())
-            powder_sqr = np.zeros(self.psi.det.shape())
-        else:
-            powder_max = np.array(self.comm.gather(self.powders['max'], root=0))
-            powder_min = np.array(self.comm.gather(self.powders['min'], root=0))
-            powder_sum = np.array(self.comm.gather(self.powders['sum'], root=0))
-            powder_sqr = np.array(self.comm.gather(self.powders['sqr'], root=0))
+        powder_max = np.array(self.comm.gather(self.powders['max'], root=0))
+        powder_min = np.array(self.comm.gather(self.powders['min'], root=0))
+        powder_sum = np.array(self.comm.gather(self.powders['sum'], root=0))
+        powder_sqr = np.array(self.comm.gather(self.powders['sqr'], root=0))
         if self.gain_map is not None:
             powder_gain = np.array(self.comm.gather(self.gain_map, root=0))
 
@@ -275,6 +280,8 @@ class RunDiagnostics:
                     print("First image of the run is an outlier and will be excluded")
                     start_idx += 1
                     
+        self.init_base_powders()
+        self.comm.Barrier()
         for idx in np.arange(start_idx, end_idx):
             if events_mask is not None and not events_mask[idx]:
                 continue

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -35,19 +35,6 @@ class RunDiagnostics:
         self.rank = self.comm.Get_rank()
         self.size = self.comm.Get_size() 
 
-    def init_base_powders(self, img_shape):
-        """
-        Initialize the base powders: sum, sum of squares, max, and min.
-
-        Parameters
-        ----------
-        img_shape : tuple, 3d
-            The shape of unassembled, calibrated images: (n_panels, n_x, n_y)
-        """
-        self.powders = dict()
-        for key in ['sum', 'sqr', 'max', 'min']:
-            self.powders[key] = np.zeros(img_shape)
-
     def compute_base_powders(self, img):
         """
         Compute the base powders: max, sum, sum of squares.
@@ -288,8 +275,6 @@ class RunDiagnostics:
                     print("First image of the run is an outlier and will be excluded")
                     start_idx += 1
                     
-        self.init_base_powders(self.psi.det.shape())
-        self.comm.Barrier()
         for idx in np.arange(start_idx, end_idx):
             if events_mask is not None and not events_mask[idx]:
                 continue

--- a/btx/diagnostics/run.py
+++ b/btx/diagnostics/run.py
@@ -229,7 +229,7 @@ class RunDiagnostics:
         evt_map = map_pixel_gain_mode_for_raw(self.psi.det, raw)
         self.gain_map[evt_map==[self.modes[gain_mode]]] += 1
             
-    def compute_run_stats(self, max_events=-1, mask=None, powder_only=False, threshold=None, total_intensity=False, gain_mode=None, raw_img=False):
+    def compute_run_stats(self, max_events=-1, mask=None, events_mask=None, powder_only=False, threshold=None, total_intensity=False, gain_mode=None, raw_img=False):
         """
         Compute powders and per-image statistics. If a mask is provided, it is 
         only applied to the stats trajectories, not in computing the powder.
@@ -240,6 +240,8 @@ class RunDiagnostics:
             number of images to process; if -1, process entire run
         mask : str or np.ndarray, shape (n_panels, n_x, n_y)
             binary mask file or array in unassembled psana shape, optional 
+        events_mask : np.ndarray, shape (n_events,)
+            boolean mask array for the run events
         powder_only : bool
             if True, only compute the powder pattern
         threshold : float
@@ -267,6 +269,9 @@ class RunDiagnostics:
                     start_idx += 1
                     
         for idx in np.arange(start_idx, end_idx):
+            if events_mask is not None and not events_mask[idx]:
+                continue
+
             evt = self.psi.runner.event(self.psi.times[idx])
             self.psi.get_timestamp(evt.get(EventId))
             if raw_img:


### PR DESCRIPTION
**Goal:** add a parameter `events_mask` to the method `compute_run_stats` in the `RunDiagnostics` class that contains a Boolean mask of considered events. If an event is marked `True`, then this event will be included in the computed "powder". Otherwise, if it is `False`, then it will not.

**Example of expected behavior:**

```python
rd = RunDiagnostics(exp='amo11416', run=1, det_type='pnccdFront')
rd.compute_run_stats(events_mask=np.array([True, False, True, ..., False, False]))
```